### PR TITLE
Add config.solve

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -1,6 +1,7 @@
 struct TestConfig
     atol::Float64 # absolute tolerance for ...
     rtol::Float64 # relative tolerance for ...
+    solve::Bool # optimize and test result
     query::Bool # can get objective function, and constraint functions, and constraint sets
     duals::Bool # test dual solutions
     infeas_certificates::Bool # check for infeasibility certificates when appropriate

--- a/src/contconic.jl
+++ b/src/contconic.jl
@@ -38,30 +38,32 @@ function lin1test(solver::Function, config::TestConfig)
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(v, [-3.0, -2.0, -4.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
+
+        @test MOI.canget(instance, MOI.VariablePrimal(), v)
+        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 0, 2] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ [-3, -1] atol=atol rtol=rtol
+        end
+
+        # TODO var dual and con primal
     end
-
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
-
-    @test MOI.canget(instance, MOI.VariablePrimal(), v)
-    @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 0, 2] atol=atol rtol=rtol
-
-    if config.duals
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ [-3, -1] atol=atol rtol=rtol
-    end
-
-    # TODO var dual and con primal
 end
 
 function lin1atest(solver::Function, config::TestConfig)
@@ -88,30 +90,32 @@ function lin1atest(solver::Function, config::TestConfig)
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(v, [-3.0, -2.0, -4.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
+
+        @test MOI.canget(instance, MOI.VariablePrimal(), v)
+        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 0, 2] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ [-3, -1] atol=atol rtol=rtol
+        end
+
+        # TODO var dual and con primal
     end
-
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
-
-    @test MOI.canget(instance, MOI.VariablePrimal(), v)
-    @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 0, 2] atol=atol rtol=rtol
-
-    if config.duals
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ [-3, -1] atol=atol rtol=rtol
-    end
-
-    # TODO var dual and con primal
 end
 
 function lin2test(solver::Function, config::TestConfig)
@@ -155,33 +159,35 @@ function lin2test(solver::Function, config::TestConfig)
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}()) == 1
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
+
+        @test MOI.canget(instance, MOI.VariablePrimal(), x)
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ -4 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ -3 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), z) ≈ 16 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), s) ≈ 0 atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ [7, 2, -4] atol=atol rtol=rtol
+        end
+
+        # TODO var dual and con primal
     end
-
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
-
-    @test MOI.canget(instance, MOI.VariablePrimal(), x)
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ -4 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ -3 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), z) ≈ 16 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), s) ≈ 0 atol=atol rtol=rtol
-
-    if config.duals
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ [7, 2, -4] atol=atol rtol=rtol
-    end
-
-    # TODO var dual and con primal
 end
 
 function lin2atest(solver::Function, config::TestConfig)
@@ -222,33 +228,35 @@ function lin2atest(solver::Function, config::TestConfig)
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
 
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
+
+        @test MOI.canget(instance, MOI.VariablePrimal(), x)
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ -4 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ -3 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), z) ≈ 16 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), s) ≈ 0 atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ [7, 2, -4] atol=atol rtol=rtol
+        end
+
+        # TODO var dual and con primal
     end
-
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
-
-    @test MOI.canget(instance, MOI.VariablePrimal(), x)
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ -4 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ -3 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), z) ≈ 16 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), s) ≈ 0 atol=atol rtol=rtol
-
-    if config.duals
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ [7, 2, -4] atol=atol rtol=rtol
-    end
-
-    # TODO var dual and con primal
 end
 
 function lin3test(solver::Function, config::TestConfig)
@@ -274,22 +282,24 @@ function lin3test(solver::Function, config::TestConfig)
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    if config.infeas_certificates
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    else
-        @test MOI.get(instance, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        if config.infeas_certificates
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        else
+            @test MOI.get(instance, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
+        end
+        if MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.InfeasiblePoint
+        end
+        if config.duals && config.infeas_certificates
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+        end
+        # TODO test dual feasibility and objective sign
     end
-    if MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.InfeasiblePoint
-    end
-    if config.duals && config.infeas_certificates
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.InfeasibilityCertificate
-    end
-    # TODO test dual feasibility and objective sign
 end
 
 function lin4test(solver::Function, config::TestConfig)
@@ -315,23 +325,25 @@ function lin4test(solver::Function, config::TestConfig)
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}()) == 1
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    if config.infeas_certificates
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    else
-        @test MOI.get(instance, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
-    end
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        if config.infeas_certificates
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        else
+            @test MOI.get(instance, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
+        end
 
-    if MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.InfeasiblePoint
+        if MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.InfeasiblePoint
+        end
+        if config.duals && config.infeas_certificates
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+        end
+        # TODO test dual feasibility and objective sign
     end
-    if config.duals && config.infeas_certificates
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.InfeasibilityCertificate
-    end
-    # TODO test dual feasibility and objective sign
 end
 
 const lintests = Dict("lin1"  => lin1test,
@@ -369,34 +381,36 @@ function soc1test(solver::Function, config::TestConfig)
     @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
     @test (MOI.VectorOfVariables,MOI.SecondOrderCone) in loc
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
+
+        @test MOI.canget(instance, MOI.VariablePrimal(), x)
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), z) ≈ 1/sqrt(2) atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(instance, MOI.ConstraintDual(), ceq)
+            @test MOI.get(instance, MOI.ConstraintDual(), ceq) ≈ [-sqrt(2)] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), csoc)
+            @test MOI.get(instance, MOI.ConstraintDual(), csoc) ≈ [sqrt(2), -1.0, -1.0] atol=atol rtol=rtol
+        end
+
+        # TODO con primal
     end
-
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
-
-    @test MOI.canget(instance, MOI.VariablePrimal(), x)
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), z) ≈ 1/sqrt(2) atol=atol rtol=rtol
-
-    if config.duals
-        @test MOI.canget(instance, MOI.ConstraintDual(), ceq)
-        @test MOI.get(instance, MOI.ConstraintDual(), ceq) ≈ [-sqrt(2)] atol=atol rtol=rtol
-        @test MOI.canget(instance, MOI.ConstraintDual(), csoc)
-        @test MOI.get(instance, MOI.ConstraintDual(), csoc) ≈ [sqrt(2), -1.0, -1.0] atol=atol rtol=rtol
-    end
-
-    # TODO con primal
 end
 
 function soc1atest(solver::Function, config::TestConfig)
@@ -422,34 +436,36 @@ function soc1atest(solver::Function, config::TestConfig)
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
+
+        @test MOI.canget(instance, MOI.VariablePrimal(), x)
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), z) ≈ 1/sqrt(2) atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(instance, MOI.ConstraintDual(), ceq)
+            @test MOI.get(instance, MOI.ConstraintDual(), ceq) ≈ [-sqrt(2)] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), csoc)
+            @test MOI.get(instance, MOI.ConstraintDual(), csoc) ≈ [sqrt(2), -1.0, -1.0] atol=atol rtol=rtol
+        end
+
+        # TODO con primal
     end
-
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
-
-    @test MOI.canget(instance, MOI.VariablePrimal(), x)
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), z) ≈ 1/sqrt(2) atol=atol rtol=rtol
-
-    if config.duals
-        @test MOI.canget(instance, MOI.ConstraintDual(), ceq)
-        @test MOI.get(instance, MOI.ConstraintDual(), ceq) ≈ [-sqrt(2)] atol=atol rtol=rtol
-        @test MOI.canget(instance, MOI.ConstraintDual(), csoc)
-        @test MOI.get(instance, MOI.ConstraintDual(), csoc) ≈ [sqrt(2), -1.0, -1.0] atol=atol rtol=rtol
-    end
-
-    # TODO con primal
 end
 
 function soc2test(solver::Function, config::TestConfig)
@@ -481,26 +497,28 @@ function soc2test(solver::Function, config::TestConfig)
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -1/sqrt(2) atol=atol rtol=rtol
+
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ -1/sqrt(2) atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
+
+        # TODO constraint primal and duals
     end
-
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -1/sqrt(2) atol=atol rtol=rtol
-
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ -1/sqrt(2) atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
-
-    # TODO constraint primal and duals
 end
 
 function soc2atest(solver::Function, config::TestConfig)
@@ -529,26 +547,28 @@ function soc2atest(solver::Function, config::TestConfig)
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -1/sqrt(2) atol=atol rtol=rtol
+
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ -1/sqrt(2) atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
+
+        # TODO constraint primal and duals
     end
-
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -1/sqrt(2) atol=atol rtol=rtol
-
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ -1/sqrt(2) atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
-
-    # TODO constraint primal and duals
 end
 
 function soc3test(solver::Function, config::TestConfig)
@@ -578,18 +598,20 @@ function soc3test(solver::Function, config::TestConfig)
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test !MOI.canget(instance, MOI.PrimalStatus())
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+        @test !MOI.canget(instance, MOI.PrimalStatus())
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+        end
+
+        # TODO test dual feasibility and objective sign
     end
-
-    # TODO test dual feasibility and objective sign
 end
 
 function soc4test(solver::Function, config::TestConfig)
@@ -631,32 +653,34 @@ function soc4test(solver::Function, config::TestConfig)
 
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x,c,0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-    end
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), x)
-    x_primal = MOI.get(instance, MOI.VariablePrimal(), x)
-    @test x_primal[1]^2 ≥ x_primal[4]^2 + x_primal[5]^2 - atol
+        @test MOI.canget(instance, MOI.VariablePrimal(), x)
+        x_primal = MOI.get(instance, MOI.VariablePrimal(), x)
+        @test x_primal[1]^2 ≥ x_primal[4]^2 + x_primal[5]^2 - atol
 
-    if config.duals
-        @test MOI.canget(instance, MOI.ConstraintDual(), c2)
-        x_dual = MOI.get(instance, MOI.ConstraintDual(), c2)
-        @test x_dual[1]^2 ≥ x_dual[2]^2 + x_dual[3]^2 - atol
+        if config.duals
+            @test MOI.canget(instance, MOI.ConstraintDual(), c2)
+            x_dual = MOI.get(instance, MOI.ConstraintDual(), c2)
+            @test x_dual[1]^2 ≥ x_dual[2]^2 + x_dual[3]^2 - atol
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), c1)
-        c1_dual = MOI.get(instance, MOI.ConstraintDual(), c1)
+            @test MOI.canget(instance, MOI.ConstraintDual(), c1)
+            c1_dual = MOI.get(instance, MOI.ConstraintDual(), c1)
 
-        @test dot(c,x_primal) ≈ -dot(c1_dual,b) atol=atol rtol=rtol
-        @test (c-A'c1_dual) ≈ [x_dual[1], 0, 0, x_dual[2], x_dual[3]] atol=atol rtol=rtol
+            @test dot(c,x_primal) ≈ -dot(c1_dual,b) atol=atol rtol=rtol
+            @test (c-A'c1_dual) ≈ [x_dual[1], 0, 0, x_dual[2], x_dual[3]] atol=atol rtol=rtol
+        end
     end
 end
 
@@ -699,44 +723,46 @@ function rotatedsoc1test(solver::Function, config::TestConfig)
 
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x,c,0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-    end
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -sqrt(2.0) atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -sqrt(2.0) atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), x)
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ [0.5, 1.0, 1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), x)
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ [0.5, 1.0, 1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
 
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus(1))
-        @test MOI.get(instance, MOI.DualStatus(1)) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus(1))
+            @test MOI.get(instance, MOI.DualStatus(1)) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
-        d1 = MOI.get(instance, MOI.ConstraintDual(), vc1)
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
-        d2 = MOI.get(instance, MOI.ConstraintDual(), vc2)
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
+            d1 = MOI.get(instance, MOI.ConstraintDual(), vc1)
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
+            d2 = MOI.get(instance, MOI.ConstraintDual(), vc2)
 
-        d = [d1, d2]
-        dualobj = dot(b, d)
-        @test dualobj ≈ -sqrt(2.0) atol=atol rtol=rtol
-        @test d1 <= atol
-        @test d2 <= atol
+            d = [d1, d2]
+            dualobj = dot(b, d)
+            @test dualobj ≈ -sqrt(2.0) atol=atol rtol=rtol
+            @test d1 <= atol
+            @test d2 <= atol
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), rsoc)
-        vardual = MOI.get(instance, MOI.ConstraintDual(), rsoc)
+            @test MOI.canget(instance, MOI.ConstraintDual(), rsoc)
+            vardual = MOI.get(instance, MOI.ConstraintDual(), rsoc)
 
-        @test vardual ≈ (c - A'd) atol=atol rtol=rtol
-        @test 2*vardual[1]*vardual[2] ≥ vardual[3]^2 + vardual[4]^2 - atol
+            @test vardual ≈ (c - A'd) atol=atol rtol=rtol
+            @test 2*vardual[1]*vardual[2] ≥ vardual[3]^2 + vardual[4]^2 - atol
+        end
     end
 end
 
@@ -762,37 +788,39 @@ function rotatedsoc1atest(solver::Function, config::TestConfig)
 
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x, [-1.0,-1.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-    end
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -sqrt(2.0) atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -sqrt(2.0) atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), x)
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ [1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), x)
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ [1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
 
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus(1))
-        @test MOI.get(instance, MOI.DualStatus(1)) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus(1))
+            @test MOI.get(instance, MOI.DualStatus(1)) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ConstraintPrimal(), rsoc)
-        @test MOI.get(instance, MOI.ConstraintPrimal(), rsoc) ≈ [0.5, 1.0, 1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintPrimal(), rsoc)
+            @test MOI.get(instance, MOI.ConstraintPrimal(), rsoc) ≈ [0.5, 1.0, 1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), rsoc)
-        d = MOI.get(instance, MOI.ConstraintDual(), rsoc)
-        @test 2*d[1]*d[2] ≥ d[3]^2 + d[4]^2 - atol
+            @test MOI.canget(instance, MOI.ConstraintDual(), rsoc)
+            d = MOI.get(instance, MOI.ConstraintDual(), rsoc)
+            @test 2*d[1]*d[2] ≥ d[3]^2 + d[4]^2 - atol
 
-        dualobj = -dot(b, d)
-        @test dualobj ≈ -sqrt(2.0) atol=atol rtol=rtol
+            dualobj = -dot(b, d)
+            @test dualobj ≈ -sqrt(2.0) atol=atol rtol=rtol
+        end
     end
 end
 
@@ -838,33 +866,35 @@ function rotatedsoc2test(solver::Function, config::TestConfig)
 
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x,c,0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
 
-    if MOI.get(instance, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleOrUnbounded] && config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) in [MOI.InfeasibilityCertificate, MOI.NearlyInfeasibilityCertificate]
+        if MOI.get(instance, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleOrUnbounded] && config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) in [MOI.InfeasibilityCertificate, MOI.NearlyInfeasibilityCertificate]
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
-        y1 = MOI.get(instance, MOI.ConstraintDual(), vc1)
-        @test y1 < -atol # Should be strictly negative
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
+            y1 = MOI.get(instance, MOI.ConstraintDual(), vc1)
+            @test y1 < -atol # Should be strictly negative
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
-        y2 = MOI.get(instance, MOI.ConstraintDual(), vc2)
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
+            y2 = MOI.get(instance, MOI.ConstraintDual(), vc2)
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc3)
-        y3 = MOI.get(instance, MOI.ConstraintDual(), vc3)
-        @test y3 > atol # Should be strictly positive
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc3)
+            y3 = MOI.get(instance, MOI.ConstraintDual(), vc3)
+            @test y3 > atol # Should be strictly positive
 
-        y = [y1, y2, y3]
+            y = [y1, y2, y3]
 
-        vardual = MOI.get(instance, MOI.ConstraintDual(), rsoc)
+            vardual = MOI.get(instance, MOI.ConstraintDual(), rsoc)
 
-        @test vardual ≈ -y atol=atol rtol=rtol
-        @test 2*vardual[1]*vardual[2] ≥ vardual[3]^2 - atol
-        @test dot(b,y) > atol
+            @test vardual ≈ -y atol=atol rtol=rtol
+            @test 2*vardual[1]*vardual[2] ≥ vardual[3]^2 - atol
+            @test dot(b,y) > atol
+        end
     end
 end
 
@@ -903,33 +933,35 @@ function _sdp0test(solver::Function, vecofvars::Bool, sdpcone, config::TestConfi
 
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([X[1], X[3]], ones(2), 0.))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-    end
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), X)
-    @test MOI.get(instance, MOI.VariablePrimal(), X) ≈ [1, s, 1] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), X)
+        @test MOI.get(instance, MOI.VariablePrimal(), X) ≈ [1, s, 1] atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.ConstraintPrimal(), cX)
-    @test MOI.get(instance, MOI.ConstraintPrimal(), cX) ≈ [1, s, 1] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), cX)
+        @test MOI.get(instance, MOI.ConstraintPrimal(), cX) ≈ [1, s, 1] atol=atol rtol=rtol
 
-    if config.duals
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ 2 atol=atol rtol=rtol
+        if config.duals
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), cX)
-        @test MOI.get(instance, MOI.ConstraintDual(), cX) ≈ [1, -s, 1] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), cX)
+            @test MOI.get(instance, MOI.ConstraintDual(), cX) ≈ [1, -s, 1] atol=atol rtol=rtol
+        end
     end
 end
 
@@ -991,65 +1023,67 @@ function _sdp1test(solver::Function, vecofvars::Bool, sdpcone, config::TestConfi
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 2
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorOfVariables, MOI.SecondOrderCone}()) == 1
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-    end
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 0.705710509 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 0.705710509 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), X)
-    Xv = MOI.get(instance, MOI.VariablePrimal(), X)
-    @test MOI.canget(instance, MOI.VariablePrimal(), x)
-    xv = MOI.get(instance, MOI.VariablePrimal(), x)
+        @test MOI.canget(instance, MOI.VariablePrimal(), X)
+        Xv = MOI.get(instance, MOI.VariablePrimal(), X)
+        @test MOI.canget(instance, MOI.VariablePrimal(), x)
+        xv = MOI.get(instance, MOI.VariablePrimal(), x)
 
-    @test MOI.get(instance, MOI.ConstraintPrimal(), cX) ≈ Xv atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.ConstraintPrimal(), cx) ≈ xv atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c1) ≈ Xv[1]+Xv[3]+Xv[6]+xv[1] atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c2) ≈ Xv[1]+2Xv[2]/s+Xv[3]+2Xv[4]/s+2Xv[5]/s+Xv[6]+xv[2]+xv[3] atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ConstraintPrimal(), cX) ≈ Xv atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ConstraintPrimal(), cx) ≈ xv atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c1) ≈ Xv[1]+Xv[3]+Xv[6]+xv[1] atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c2) ≈ Xv[1]+2Xv[2]/s+Xv[3]+2Xv[4]/s+2Xv[5]/s+Xv[6]+xv[2]+xv[3] atol=atol rtol=rtol
 
-    if config.duals
-        @test MOI.canget(instance, MOI.ConstraintDual(), c1)
-        y1 = MOI.get(instance, MOI.ConstraintDual(), c1)
-        @test MOI.canget(instance, MOI.ConstraintDual(), c2)
-        y2 = MOI.get(instance, MOI.ConstraintDual(), c2)
+        if config.duals
+            @test MOI.canget(instance, MOI.ConstraintDual(), c1)
+            y1 = MOI.get(instance, MOI.ConstraintDual(), c1)
+            @test MOI.canget(instance, MOI.ConstraintDual(), c2)
+            y2 = MOI.get(instance, MOI.ConstraintDual(), c2)
 
-        #     X11  X21  X22  X31  X32  X33  x1  x2  x3
-        c = [   2, 2/s,   2,   0, 2/s,   2,  1,  0,  0]
-        b = [1, 1/2]
-        # Check primal objective
-        comp_pobj = dot(c, [Xv; xv])
-        # Check dual objective
-        comp_dobj = dot([y1, y2], b)
-        @test comp_pobj ≈ comp_dobj atol=atol rtol=rtol
+            #     X11  X21  X22  X31  X32  X33  x1  x2  x3
+            c = [   2, 2/s,   2,   0, 2/s,   2,  1,  0,  0]
+            b = [1, 1/2]
+            # Check primal objective
+            comp_pobj = dot(c, [Xv; xv])
+            # Check dual objective
+            comp_dobj = dot([y1, y2], b)
+            @test comp_pobj ≈ comp_dobj atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), cX)
-        Xdv = MOI.get(instance, MOI.ConstraintDual(), cX)
-        Xd = [Xdv[1]   Xdv[2]/s Xdv[4]/s;
-              Xdv[2]/s Xdv[3]   Xdv[5]/s;
-              Xdv[4]/s Xdv[5]/s Xdv[6]]
+            @test MOI.canget(instance, MOI.ConstraintDual(), cX)
+            Xdv = MOI.get(instance, MOI.ConstraintDual(), cX)
+            Xd = [Xdv[1]   Xdv[2]/s Xdv[4]/s;
+                  Xdv[2]/s Xdv[3]   Xdv[5]/s;
+                  Xdv[4]/s Xdv[5]/s Xdv[6]]
 
-        C = [2 1 0;
-             1 2 1;
-             0 1 2]
-        A1 = [1 0 0;
-              0 1 0;
-              0 0 1]
-        A2 = [1 1 1;
-              1 1 1;
-              1 1 1]
+            C = [2 1 0;
+                 1 2 1;
+                 0 1 2]
+            A1 = [1 0 0;
+                  0 1 0;
+                  0 0 1]
+            A2 = [1 1 1;
+                  1 1 1;
+                  1 1 1]
 
-        @test C ≈ y1 * A1 + y2 * A2 + Xd atol=atol rtol=rtol
+            @test C ≈ y1 * A1 + y2 * A2 + Xd atol=atol rtol=rtol
 
-        @test eigmin(Xd) > -max(atol, rtol)
+            @test eigmin(Xd) > -max(atol, rtol)
+        end
     end
 end
 
@@ -1094,62 +1128,64 @@ function sdp2test(solver::Function, config::TestConfig)
 
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x[7]], [1.], 0.))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-    end
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), x)
-    xv = MOI.get(instance, MOI.VariablePrimal(), x)
-    @test all(xv[1:6] .> -atol)
+        @test MOI.canget(instance, MOI.VariablePrimal(), x)
+        xv = MOI.get(instance, MOI.VariablePrimal(), x)
+        @test all(xv[1:6] .> -atol)
 
-    con = A * xv + b
+        con = A * xv + b
 
-    @test MOI.canget(instance, MOI.ConstraintPrimal(), c1)
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c1) ≈ con[1] atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c1) ≈ 0.0 atol=atol rtol=rtol
-    @test MOI.canget(instance, MOI.ConstraintPrimal(), c2)
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c2) ≈ con[2:7] atol=atol rtol=rtol
-    @test all(MOI.get(instance, MOI.ConstraintPrimal(), c2) .< atol)
-    @test MOI.canget(instance, MOI.ConstraintPrimal(), c3)
-    Xv = MOI.get(instance, MOI.ConstraintPrimal(), c3)
-    @test Xv ≈ con[8:10] atol=atol rtol=rtol
-    s2 = sqrt(2)
-    Xm = [Xv[1]    Xv[2]/s2
-          Xv[2]/s2 Xv[3]]
-    @test eigmin(Xm) > -atol
-    @test MOI.canget(instance, MOI.ConstraintPrimal(), c4)
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c4) ≈ con[11] atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c4) ≈ 0.0 atol=atol rtol=rtol
-
-    if config.duals
-        @test MOI.canget(instance, MOI.ConstraintDual(), c1)
-        y1 = MOI.get(instance, MOI.ConstraintDual(), c1)
-        @test y1 > -atol
-        @test MOI.canget(instance, MOI.ConstraintDual(), c2)
-        y2 = MOI.get(instance, MOI.ConstraintDual(), c2)
-        @test all(MOI.get(instance, MOI.ConstraintDual(), c2) .< atol)
-
-        @test MOI.canget(instance, MOI.ConstraintDual(), c3)
-        y3 = MOI.get(instance, MOI.ConstraintDual(), c3)
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), c1)
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c1) ≈ con[1] atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c1) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), c2)
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c2) ≈ con[2:7] atol=atol rtol=rtol
+        @test all(MOI.get(instance, MOI.ConstraintPrimal(), c2) .< atol)
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), c3)
+        Xv = MOI.get(instance, MOI.ConstraintPrimal(), c3)
+        @test Xv ≈ con[8:10] atol=atol rtol=rtol
         s2 = sqrt(2)
-        Ym = [y3[1]    y3[2]/s2
-              y3[2]/s2 y3[3]]
-        @test eigmin(Ym) > -atol
+        Xm = [Xv[1]    Xv[2]/s2
+              Xv[2]/s2 Xv[3]]
+        @test eigmin(Xm) > -atol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), c4)
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c4) ≈ con[11] atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c4) ≈ 0.0 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), c4)
-        y4 = MOI.get(instance, MOI.ConstraintDual(), c4)
+        if config.duals
+            @test MOI.canget(instance, MOI.ConstraintDual(), c1)
+            y1 = MOI.get(instance, MOI.ConstraintDual(), c1)
+            @test y1 > -atol
+            @test MOI.canget(instance, MOI.ConstraintDual(), c2)
+            y2 = MOI.get(instance, MOI.ConstraintDual(), c2)
+            @test all(MOI.get(instance, MOI.ConstraintDual(), c2) .< atol)
 
-        y = [y1; y2; y3; y4]
-        @test dot(c, xv) ≈ dot(b, y) atol=atol rtol=rtol
-        @test A' * y ≈ -c atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), c3)
+            y3 = MOI.get(instance, MOI.ConstraintDual(), c3)
+            s2 = sqrt(2)
+            Ym = [y3[1]    y3[2]/s2
+                  y3[2]/s2 y3[3]]
+            @test eigmin(Ym) > -atol
+
+            @test MOI.canget(instance, MOI.ConstraintDual(), c4)
+            y4 = MOI.get(instance, MOI.ConstraintDual(), c4)
+
+            y = [y1; y2; y3; y4]
+            @test dot(c, xv) ≈ dot(b, y) atol=atol rtol=rtol
+            @test A' * y ≈ -c atol=atol rtol=rtol
+        end
     end
 end
 

--- a/src/contlinear.jl
+++ b/src/contlinear.jl
@@ -57,34 +57,36 @@ function linear1test(solver::Function, config::TestConfig)
         @test s == MOI.GreaterThan(0.0)
     end
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), v)
-    @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), v)
+        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.ConstraintPrimal(), c)
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), c)
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
-        # reduced costs
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+            # reduced costs
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+        end
     end
 
     # change objective to Max +x
@@ -100,30 +102,32 @@ function linear1test(solver::Function, config::TestConfig)
 
     @test MOI.get(instance, MOI.ObjectiveSense()) == MOI.MaxSense
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), v)
-    @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), v)
+        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
 
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+        end
     end
 
     # add new variable to get :
@@ -147,38 +151,40 @@ function linear1test(solver::Function, config::TestConfig)
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    @test MOI.get(instance, MOI.ResultCount()) >= 1
+        @test MOI.canget(instance, MOI.ResultCount())
+        @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-    @test MOI.canget(instance, MOI.PrimalStatus(1))
-    @test MOI.get(instance, MOI.PrimalStatus(1)) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus(1))
+        @test MOI.get(instance, MOI.PrimalStatus(1)) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), v)
-    @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0, 0, 1] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), v)
+        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0, 0, 1] atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.ConstraintPrimal(), c)
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), c)
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -2 atol=atol rtol=rtol
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -2 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc1) ≈ 1 atol=atol rtol=rtol
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc2) ≈ 2 atol=atol rtol=rtol
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc3)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc3) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc1) ≈ 1 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc2) ≈ 2 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc3)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc3) ≈ 0 atol=atol rtol=rtol
+        end
     end
 
     # setting lb of x to -1 to get :
@@ -189,19 +195,21 @@ function linear1test(solver::Function, config::TestConfig)
     @test MOI.canmodifyconstraint(instance, vc1, MOI.GreaterThan(-1.0))
     MOI.modifyconstraint!(instance, vc1, MOI.GreaterThan(-1.0))
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    @test MOI.get(instance, MOI.ResultCount()) >= 1
+        @test MOI.canget(instance, MOI.ResultCount())
+        @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+    end
 
     # put lb of x back to 0 and fix z to zero to get :
     # max x + 2z
@@ -216,44 +224,46 @@ function linear1test(solver::Function, config::TestConfig)
     vc3 = MOI.addconstraint!(instance, MOI.SingleVariable(v[3]), MOI.EqualTo(0.0))
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    @test MOI.get(instance, MOI.ResultCount()) >= 1
+        @test MOI.canget(instance, MOI.ResultCount())
+        @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
-    # modify affine linear constraint set to be == 2 to get :
-    # max x + 2z
-    # s.t. x + y + z == 2
-    # x,y >= 0, z = 0
-    @test MOI.candelete(instance, c)
-    MOI.delete!(instance, c)
-    cf = MOI.ScalarAffineFunction(v, [1.0,1.0,1.0], 0.0)
-    c = MOI.addconstraint!(instance, cf, MOI.EqualTo(2.0))
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
+        # modify affine linear constraint set to be == 2 to get :
+        # max x + 2z
+        # s.t. x + y + z == 2
+        # x,y >= 0, z = 0
+        @test MOI.candelete(instance, c)
+        MOI.delete!(instance, c)
+        cf = MOI.ScalarAffineFunction(v, [1.0,1.0,1.0], 0.0)
+        c = MOI.addconstraint!(instance, cf, MOI.EqualTo(2.0))
+        @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
+        @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
 
-    MOI.optimize!(instance)
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    @test MOI.get(instance, MOI.ResultCount()) >= 1
+        @test MOI.canget(instance, MOI.ResultCount())
+        @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+    end
 
     # modify objective function to x + 2y to get :
     # max x + 2y
@@ -264,22 +274,24 @@ function linear1test(solver::Function, config::TestConfig)
     MOI.set!(instance, MOI.ObjectiveFunction(), objf)
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    @test MOI.get(instance, MOI.ResultCount()) >= 1
+        @test MOI.canget(instance, MOI.ResultCount())
+        @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), v)
-    @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0, 2, 0] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), v)
+        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0, 2, 0] atol=atol rtol=rtol
+    end
 
     # add constraint x - y >= 0 to get :
     # max x+2y
@@ -293,40 +305,42 @@ function linear1test(solver::Function, config::TestConfig)
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    @test MOI.get(instance, MOI.ResultCount()) >= 1
+        @test MOI.canget(instance, MOI.ResultCount())
+        @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), v)
-    @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 1, 0] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), v)
+        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 1, 0] atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.ConstraintPrimal(), c)
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), c)
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
 
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus(1))
-        @test MOI.get(instance, MOI.DualStatus(1)) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus(1))
+            @test MOI.get(instance, MOI.DualStatus(1)) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -1.5 atol=atol rtol=rtol
-        @test MOI.get(instance, MOI.ConstraintDual(), c2) ≈ 0.5 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -1.5 atol=atol rtol=rtol
+            @test MOI.get(instance, MOI.ConstraintDual(), c2) ≈ 0.5 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc2) ≈ 0 atol=atol rtol=rtol
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc3)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc3) ≈ 1.5 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc2) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc3)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc3) ≈ 1.5 atol=atol rtol=rtol
+        end
     end
 end
 
@@ -361,37 +375,39 @@ function linear2test(solver::Function, config::TestConfig)
 
     @test MOI.get(instance, MOI.ObjectiveSense()) == MOI.MinSense
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), x)
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), x)
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), y)
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), y)
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.ConstraintPrimal(), c)
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), c)
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
-    if config.duals
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
-        # reduced costs
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-        @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
-        @test MOI.get(instance, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+            # reduced costs
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc1)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), vc2)
+            @test MOI.get(instance, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+        end
     end
 end
 
@@ -419,19 +435,21 @@ function linear3test(solver::Function, config::TestConfig)
     MOI.set!(instance, MOI.ObjectiveFunction(), objf)
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    @test MOI.get(instance, MOI.ResultCount()) >= 1
+        @test MOI.canget(instance, MOI.ResultCount())
+        @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+    end
 
     # max  x
     # s.t. x <= 0
@@ -453,19 +471,21 @@ function linear3test(solver::Function, config::TestConfig)
     MOI.set!(instance, MOI.ObjectiveFunction(), objf)
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    @test MOI.get(instance, MOI.ResultCount()) >= 1
+        @test MOI.canget(instance, MOI.ResultCount())
+        @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 0 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 0 atol=atol rtol=rtol
+    end
 end
 
 # Modify GreaterThan and LessThan sets as bounds
@@ -490,40 +510,46 @@ function linear4test(solver::Function, config::TestConfig)
     c1 = MOI.addconstraint!(instance, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
     c2 = MOI.addconstraint!(instance, MOI.SingleVariable(y), MOI.LessThan(0.0))
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
 
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= 0.0
     @test MOI.canmodifyconstraint(instance, c1, MOI.GreaterThan(100.0))
     MOI.modifyconstraint!(instance, c1, MOI.GreaterThan(100.0))
-    MOI.optimize!(instance)
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+    if config.solve
+        MOI.optimize!(instance)
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
 
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= -100.0
     @test MOI.canmodifyconstraint(instance, c2, MOI.LessThan(-100.0))
     MOI.modifyconstraint!(instance, c2, MOI.LessThan(-100.0))
-    MOI.optimize!(instance)
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+    if config.solve
+        MOI.optimize!(instance)
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+    end
 end
 
 # Change coeffs, del constr, del var
@@ -571,19 +597,21 @@ function linear5test(solver::Function, config::TestConfig)
     MOI.set!(instance, MOI.ObjectiveFunction(), objf)
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 8/3 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 8/3 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), [x, y])
-    @test MOI.get(instance, MOI.VariablePrimal(), [x, y]) ≈ [4/3, 4/3] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), [x, y])
+        @test MOI.get(instance, MOI.VariablePrimal(), [x, y]) ≈ [4/3, 4/3] atol=atol rtol=rtol
+    end
 
     # copy and solve again
     # missing test
@@ -599,19 +627,21 @@ function linear5test(solver::Function, config::TestConfig)
 
     @test MOI.canmodifyconstraint(instance, c1, MOI.ScalarCoefficientChange(y, 3.0))
     MOI.modifyconstraint!(instance, c1, MOI.ScalarCoefficientChange(y, 3.0))
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), [x, y])
-    @test MOI.get(instance, MOI.VariablePrimal(), [x, y]) ≈ [2.0, 0.0] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), [x, y])
+        @test MOI.get(instance, MOI.VariablePrimal(), [x, y]) ≈ [2.0, 0.0] atol=atol rtol=rtol
+    end
 
     # delconstrs and solve
     #   maximize x + y
@@ -623,19 +653,21 @@ function linear5test(solver::Function, config::TestConfig)
     @test MOI.candelete(instance, c1)
     MOI.delete!(instance, c1)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), [x, y])
-    @test MOI.get(instance, MOI.VariablePrimal(), [x, y]) ≈ [4.0, 0.0] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), [x, y])
+        @test MOI.get(instance, MOI.VariablePrimal(), [x, y]) ≈ [4.0, 0.0] atol=atol rtol=rtol
+    end
 
     # delvars and solve
     #   maximize y
@@ -647,19 +679,21 @@ function linear5test(solver::Function, config::TestConfig)
     @test MOI.candelete(instance, x)
     MOI.delete!(instance, x)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), y)
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 2.0 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), y)
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 2.0 atol=atol rtol=rtol
+    end
 end
 
 # Modify GreaterThan and LessThan sets as linear constraints
@@ -684,40 +718,46 @@ function linear6test(solver::Function, config::TestConfig)
     c1 = MOI.addconstraint!(instance, MOI.ScalarAffineFunction([x],[1.0],0.0), MOI.GreaterThan(0.0))
     c2 = MOI.addconstraint!(instance, MOI.ScalarAffineFunction([y],[1.0],0.0), MOI.LessThan(0.0))
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
 
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= 0.0
     @test MOI.canmodifyconstraint(instance, c1, MOI.GreaterThan(100.0))
     MOI.modifyconstraint!(instance, c1, MOI.GreaterThan(100.0))
-    MOI.optimize!(instance)
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+    if config.solve
+        MOI.optimize!(instance)
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
 
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= -100.0
     @test MOI.canmodifyconstraint(instance, c2, MOI.LessThan(-100.0))
     MOI.modifyconstraint!(instance, c2, MOI.LessThan(-100.0))
-    MOI.optimize!(instance)
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+    if config.solve
+        MOI.optimize!(instance)
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+    end
 end
 
 # Modify constants in Nonnegatives and Nonpositives
@@ -742,40 +782,46 @@ function linear7test(solver::Function, config::TestConfig)
     c1 = MOI.addconstraint!(instance, MOI.VectorAffineFunction([1],[x],[1.0],[0.0]), MOI.Nonnegatives(1))
     c2 = MOI.addconstraint!(instance, MOI.VectorAffineFunction([1],[y],[1.0],[0.0]), MOI.Nonpositives(1))
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
 
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= 0.0
     @test MOI.canmodifyconstraint(instance, c1, MOI.VectorConstantChange([-100.0]))
     MOI.modifyconstraint!(instance, c1, MOI.VectorConstantChange([-100.0]))
-    MOI.optimize!(instance)
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+    if config.solve
+        MOI.optimize!(instance)
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
 
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= -100.0
     @test MOI.canmodifyconstraint(instance, c2, MOI.VectorConstantChange([100.0]))
     MOI.modifyconstraint!(instance, c2, MOI.VectorConstantChange([100.0]))
-    MOI.optimize!(instance)
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+    if config.solve
+        MOI.optimize!(instance)
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+    end
 end
 
 # infeasible problem
@@ -795,30 +841,32 @@ function linear8atest(solver::Function, config::TestConfig)
     bndy = MOI.addconstraint!(instance, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x], [1.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    if config.infeas_certificates
-        # solver returned an infeasibility ray
-        @test MOI.get(instance, MOI.ResultCount()) >= 1
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.InfeasibilityCertificate
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        cd = MOI.get(instance, MOI.ConstraintDual(), c)
-        @test cd < -atol
-        # TODO: farkas dual on bounds - see #127
-        # xd = MOI.get(instance, MOI.ConstraintDual(), bndx)
-        # yd = MOI.get(instance, MOI.ConstraintDual(), bndy)
-        # @test xd > atol
-        # @test yd > atol
-        # @test yd ≈ -cd atol=atol rtol=rtol
-        # @test xd ≈ -2cd atol=atol rtol=rtol
-    else
-        # solver returned nothing
-        @test MOI.get(instance, MOI.ResultCount()) == 0
-        @test MOI.canget(instance, MOI.PrimalStatus(1)) == false
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
-            MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        @test MOI.canget(instance, MOI.ResultCount())
+        if config.infeas_certificates
+            # solver returned an infeasibility ray
+            @test MOI.get(instance, MOI.ResultCount()) >= 1
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            cd = MOI.get(instance, MOI.ConstraintDual(), c)
+            @test cd < -atol
+            # TODO: farkas dual on bounds - see #127
+            # xd = MOI.get(instance, MOI.ConstraintDual(), bndx)
+            # yd = MOI.get(instance, MOI.ConstraintDual(), bndy)
+            # @test xd > atol
+            # @test yd > atol
+            # @test yd ≈ -cd atol=atol rtol=rtol
+            # @test xd ≈ -2cd atol=atol rtol=rtol
+        else
+            # solver returned nothing
+            @test MOI.get(instance, MOI.ResultCount()) == 0
+            @test MOI.canget(instance, MOI.PrimalStatus(1)) == false
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
+                MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        end
     end
 end
 
@@ -839,20 +887,22 @@ function linear8btest(solver::Function, config::TestConfig)
     MOI.addconstraint!(instance, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [-1.0, -1.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    if config.infeas_certificates
-        # solver returned an unbounded ray
-        @test MOI.get(instance, MOI.ResultCount()) >= 1
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
-    else
-        # solver returned nothing
-        @test MOI.get(instance, MOI.ResultCount()) == 0
-        @test MOI.canget(instance, MOI.PrimalStatus(1)) == false
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
-            MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        @test MOI.canget(instance, MOI.ResultCount())
+        if config.infeas_certificates
+            # solver returned an unbounded ray
+            @test MOI.get(instance, MOI.ResultCount()) >= 1
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
+        else
+            # solver returned nothing
+            @test MOI.get(instance, MOI.ResultCount()) == 0
+            @test MOI.canget(instance, MOI.PrimalStatus(1)) == false
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
+                MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        end
     end
 end
 
@@ -873,24 +923,26 @@ function linear8ctest(solver::Function, config::TestConfig)
     MOI.addconstraint!(instance, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
     MOI.set!(instance, MOI.ObjectiveFunction(),MOI.ScalarAffineFunction([x, y], [-1.0, -1.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    if config.infeas_certificates
-        # solver returned an unbounded ray
-        @test MOI.get(instance, MOI.ResultCount()) >= 1
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
-        @test MOI.canget(instance, MOI.VariablePrimal(), [x, y])
-        ray = MOI.get(instance, MOI.VariablePrimal(), [x,y])
-        @test ray[1] ≈ ray[2] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ResultCount())
+        if config.infeas_certificates
+            # solver returned an unbounded ray
+            @test MOI.get(instance, MOI.ResultCount()) >= 1
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.canget(instance, MOI.VariablePrimal(), [x, y])
+            ray = MOI.get(instance, MOI.VariablePrimal(), [x,y])
+            @test ray[1] ≈ ray[2] atol=atol rtol=rtol
 
-    else
-        # solver returned nothing
-        @test MOI.get(instance, MOI.ResultCount()) == 0
-        @test MOI.canget(instance, MOI.PrimalStatus(1)) == false
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
-            MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        else
+            # solver returned nothing
+            @test MOI.get(instance, MOI.ResultCount()) == 0
+            @test MOI.canget(instance, MOI.PrimalStatus(1)) == false
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
+                MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        end
     end
 end
 
@@ -945,14 +997,16 @@ function linear9test(solver::Function, config::TestConfig)
                       MOI.ScalarAffineFunction([x, y], [1_000.0, 350.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 79e4/11 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 650/11 atol=atol rtol=rtol
-    @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 400/11 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 79e4/11 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 650/11 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 400/11 atol=atol rtol=rtol
+    end
 end
 
 # ranged constraints
@@ -984,53 +1038,62 @@ function linear10test(solver::Function, config::TestConfig)
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 10.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 10.0 atol=atol rtol=rtol
 
-    if config.duals
-        @test MOI.get(instance, MOI.ResultCount()) >= 1
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+        if config.duals
+            @test MOI.get(instance, MOI.ResultCount()) >= 1
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+        end
     end
 
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 5.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 5.0 atol=atol rtol=rtol
 
-    if config.duals
-        @test MOI.get(instance, MOI.ResultCount()) >= 1
-        @test MOI.canget(instance, MOI.DualStatus())
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
-        @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
+        if config.duals
+            @test MOI.get(instance, MOI.ResultCount()) >= 1
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
+        end
     end
 
     @test MOI.canmodifyconstraint(instance, c, MOI.Interval(2.0, 12.0))
     MOI.modifyconstraint!(instance, c, MOI.Interval(2.0, 12.0))
-    MOI.optimize!(instance)
 
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+    if config.solve
+        MOI.optimize!(instance)
+
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+    end
 
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 12.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 12.0 atol=atol rtol=rtol
+    end
 end
 
 # changing constraint sense
@@ -1058,11 +1121,13 @@ function linear11test(solver::Function, config::TestConfig)
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+    end
 
     @test MOI.cantransformconstraint(instance, c2, MOI.LessThan(2.0))
     c3 = MOI.transformconstraint!(instance, c2, MOI.LessThan(2.0))
@@ -1071,11 +1136,13 @@ function linear11test(solver::Function, config::TestConfig)
     @test MOI.isvalid(instance, c2) == false
     @test MOI.isvalid(instance, c3) == true
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 1.0 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 1.0 atol=atol rtol=rtol
+    end
 end
 
 # infeasible problem with 2 linear constraints
@@ -1097,30 +1164,33 @@ function linear12test(solver::Function, config::TestConfig)
     bndy = MOI.addconstraint!(instance, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x], [1.0], 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
-    MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    if config.infeas_certificates
-        # solver returned an infeasibility ray
-        @test MOI.get(instance, MOI.ResultCount()) >= 1
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.get(instance, MOI.DualStatus()) == MOI.InfeasibilityCertificate
-        @test MOI.canget(instance, MOI.ConstraintDual(), c1)
-        cd1 = MOI.get(instance, MOI.ConstraintDual(), c1)
-        cd2 = MOI.get(instance, MOI.ConstraintDual(), c2)
-        bndxd = MOI.get(instance, MOI.ConstraintDual(), bndx)
-        bndyd = MOI.get(instance, MOI.ConstraintDual(), bndy)
-        @test cd1 < - atol
-        @test cd2 < - atol
-        @test - 3 * cd1 + cd2 ≈ -bndyd atol=atol rtol=rtol
-        @test 2 * cd1 ≈ -bndxd atol=atol rtol=rtol
-        @test -7 * cd1 + 2 * cd2 > atol
-    else
-        # solver returned nothing
-        @test MOI.get(instance, MOI.ResultCount()) == 0
-        @test MOI.canget(instance, MOI.PrimalStatus(1)) == false
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
-            MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+    if config.solve
+        MOI.optimize!(instance)
+
+        @test MOI.canget(instance, MOI.ResultCount())
+        if config.infeas_certificates
+            # solver returned an infeasibility ray
+            @test MOI.get(instance, MOI.ResultCount()) >= 1
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.canget(instance, MOI.ConstraintDual(), c1)
+            cd1 = MOI.get(instance, MOI.ConstraintDual(), c1)
+            cd2 = MOI.get(instance, MOI.ConstraintDual(), c2)
+            bndxd = MOI.get(instance, MOI.ConstraintDual(), bndx)
+            bndyd = MOI.get(instance, MOI.ConstraintDual(), bndy)
+            @test cd1 < - atol
+            @test cd2 < - atol
+            @test - 3 * cd1 + cd2 ≈ -bndyd atol=atol rtol=rtol
+            @test 2 * cd1 ≈ -bndxd atol=atol rtol=rtol
+            @test -7 * cd1 + 2 * cd2 > atol
+        else
+            # solver returned nothing
+            @test MOI.get(instance, MOI.ResultCount()) == 0
+            @test MOI.canget(instance, MOI.PrimalStatus(1)) == false
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
+                MOI.get(instance, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        end
     end
 end
 

--- a/src/contquadratic.jl
+++ b/src/contquadratic.jl
@@ -42,19 +42,21 @@ function qp1test(solver::Function, config::TestConfig)
             @test MOI.GreaterThan(4.0) == MOI.get(instance, MOI.ConstraintSet(), c1)
         end
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 130/70 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 130/70 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.VariablePrimal(), v)
-        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), v)
+            @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+        end
     end
 end
 
@@ -100,19 +102,21 @@ function qp2test(solver::Function, config::TestConfig)
             @test MOI.GreaterThan(4.0) == MOI.get(instance, MOI.ConstraintSet(), c1)
         end
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 130/70 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 130/70 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.VariablePrimal(), v)
-        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), v)
+            @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+        end
 
         # change objective to Max -2(x^2 + xy + y^2 + yz + z^2)
         obj2 = MOI.ScalarQuadraticFunction(v, [0.0,0.0,0.0],[v[1], v[1], v[1], v[2], v[2], v[3], v[3]], [v[1], v[2], v[2], v[2], v[3], v[3], v[3]], [-4.0, -1.0, -1.0, -4.0, -2.0, -2.0, -2.0], 0.0)
@@ -125,19 +129,21 @@ function qp2test(solver::Function, config::TestConfig)
             @test obj2 ≈ MOI.get(instance, MOI.ObjectiveFunction())
         end
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -2*130/70 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -2*130/70 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.VariablePrimal(), v)
-        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), v)
+            @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+        end
     end
 end
 
@@ -177,18 +183,20 @@ function qp3test(solver::Function, config::TestConfig)
         MOI.set!(instance, MOI.ObjectiveFunction(), obj)
         MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2.875 atol=atol rtol=rtol
-        @test MOI.canget(instance, MOI.VariablePrimal(), [x,y])
-        @test MOI.get(instance, MOI.VariablePrimal(), [x,y]) ≈ [0.25, 0.75] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2.875 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), [x,y])
+            @test MOI.get(instance, MOI.VariablePrimal(), [x,y]) ≈ [0.25, 0.75] atol=atol rtol=rtol
+        end
 
         # change back to linear
         #        max 2x + y + 1
@@ -199,18 +207,20 @@ function qp3test(solver::Function, config::TestConfig)
         MOI.set!(instance, MOI.ObjectiveFunction(), objf)
         MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
-        @test MOI.canget(instance, MOI.VariablePrimal(), [x,y])
-        @test MOI.get(instance, MOI.VariablePrimal(), [x,y]) ≈ [1.0, 0.0] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), [x,y])
+            @test MOI.get(instance, MOI.VariablePrimal(), [x,y]) ≈ [1.0, 0.0] atol=atol rtol=rtol
+        end
 
     end
 end
@@ -262,19 +272,21 @@ function qcp1test(solver::Function, config::TestConfig)
             @test c2f ≈ MOI.get(instance, MOI.ConstraintFunction(), c2)
         end
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2.25 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 2.25 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.VariablePrimal(), [x,y])
-        @test MOI.get(instance, MOI.VariablePrimal(), [x,y]) ≈ [0.5,1.75] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), [x,y])
+            @test MOI.get(instance, MOI.VariablePrimal(), [x,y]) ≈ [0.5,1.75] atol=atol rtol=rtol
+        end
 
         # try delete quadratic constraint and go back to linear
 
@@ -321,28 +333,30 @@ function qcp2test(solver::Function, config::TestConfig)
             @test cf ≈ MOI.get(instance, MOI.ConstraintFunction(), c)
         end
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        if config.duals
-            @test MOI.canget(instance, MOI.DualStatus())
-            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+            if config.duals
+                @test MOI.canget(instance, MOI.DualStatus())
+                @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+            end
+
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
+
+            @test MOI.canget(instance, MOI.VariablePrimal(), x)
+            @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
+
+            # TODO - duals
+            # @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            # @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ 0.5/sqrt(2) atol=atol rtol=rtol
         end
-
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
-
-        @test MOI.canget(instance, MOI.VariablePrimal(), x)
-        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
-
-        # TODO - duals
-        # @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        # @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ 0.5/sqrt(2) atol=atol rtol=rtol
     end
 end
 
@@ -373,28 +387,30 @@ function qcp3test(solver::Function, config::TestConfig)
             @test cf ≈ MOI.get(instance, MOI.ConstraintFunction(), c)
         end
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        if config.duals
-            @test MOI.canget(instance, MOI.DualStatus())
-            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+            if config.duals
+                @test MOI.canget(instance, MOI.DualStatus())
+                @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+            end
+
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -sqrt(2) atol=atol rtol=rtol
+
+            @test MOI.canget(instance, MOI.VariablePrimal(), x)
+            @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
+
+            # TODO - duals
+            # @test MOI.canget(instance, MOI.ConstraintDual(), c)
+            # @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -0.5/sqrt(2) atol=atol rtol=rtol
         end
-
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -sqrt(2) atol=atol rtol=rtol
-
-        @test MOI.canget(instance, MOI.VariablePrimal(), x)
-        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
-
-        # TODO - duals
-        # @test MOI.canget(instance, MOI.ConstraintDual(), c)
-        # @test MOI.get(instance, MOI.ConstraintDual(), c) ≈ -0.5/sqrt(2) atol=atol rtol=rtol
     end
 end
 
@@ -451,22 +467,24 @@ function socp1test(solver::Function, config::TestConfig)
             @test c2f ≈ MOI.get(instance, MOI.ConstraintFunction(), c2)
         end
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ sqrt(1/2) atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ sqrt(1/2) atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.VariablePrimal(), [x,y,t])
-        @test MOI.get(instance, MOI.VariablePrimal(), [x,y,t]) ≈ [0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), [x,y,t])
+            @test MOI.get(instance, MOI.VariablePrimal(), [x,y,t]) ≈ [0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.VariablePrimal(), [t,x,y,t])
-        @test MOI.get(instance, MOI.VariablePrimal(), [t,x,y,t]) ≈ [sqrt(1/2),0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), [t,x,y,t])
+            @test MOI.get(instance, MOI.VariablePrimal(), [t,x,y,t]) ≈ [sqrt(1/2),0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
+        end
     end
 end
 

--- a/src/intconic.jl
+++ b/src/intconic.jl
@@ -33,21 +33,23 @@ function intsoc1test(solver::Function; atol=Base.rtoldefault(Float64), rtol=Base
         bin1 = MOI.addconstraint!(instance, MOI.SingleVariable(y), MOI.ZeroOne)
         bin2 = MOI.addconstraint!(instance, MOI.SingleVariable(z), MOI.ZeroOne)
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -2 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ -2 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.VariablePrimal(), x)
-        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
-        @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 1 atol=atol rtol=rtol
-        @test MOI.get(instance, MOI.VariablePrimal(), z) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), x)
+            @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+            @test MOI.get(instance, MOI.VariablePrimal(), y) ≈ 1 atol=atol rtol=rtol
+            @test MOI.get(instance, MOI.VariablePrimal(), z) ≈ 0 atol=atol rtol=rtol
+        end
 
     end
 end

--- a/src/intlinear.jl
+++ b/src/intlinear.jl
@@ -48,48 +48,50 @@ function int1test(solver::Function, config::TestConfig)
 
     @test MOI.get(instance, MOI.ObjectiveSense()) == MOI.MaxSense
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.ResultCount())
-    @test MOI.get(instance, MOI.ResultCount()) >= 1
+        @test MOI.canget(instance, MOI.ResultCount())
+        @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 19.4 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 19.4 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), v)
-    @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [4,5,1] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), v)
+        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [4,5,1] atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.ConstraintPrimal(), c)
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c) ≈ 10 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), c)
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c) ≈ 10 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.ConstraintPrimal(), c2)
-    @test MOI.get(instance, MOI.ConstraintPrimal(), c2) ≈ 15 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), c2)
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c2) ≈ 15 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.DualStatus()) == false
+        @test MOI.canget(instance, MOI.DualStatus()) == false
 
-    if MOI.canget(instance, MOI.ObjectiveBound())
-        @test MOI.get(instance, MOI.ObjectiveBound()) >= 19.4
-    end
-    if MOI.canget(instance, MOI.RelativeGap())
-        @test MOI.get(instance, MOI.RelativeGap()) >= 0.0
-    end
-    if MOI.canget(instance, MOI.SolveTime())
-        @test MOI.get(instance, MOI.SolveTime()) >= 0.0
-    end
-    if MOI.canget(instance, MOI.SimplexIterations())
-        @test MOI.get(instance, MOI.SimplexIterations()) >= 0
-    end
-    if MOI.canget(instance, MOI.BarrierIterations())
-        @test MOI.get(instance, MOI.BarrierIterations()) >= 0
-    end
-    if MOI.canget(instance, MOI.NodeCount())
-        @test MOI.get(instance, MOI.NodeCount()) >= 0
+        if MOI.canget(instance, MOI.ObjectiveBound())
+            @test MOI.get(instance, MOI.ObjectiveBound()) >= 19.4
+        end
+        if MOI.canget(instance, MOI.RelativeGap())
+            @test MOI.get(instance, MOI.RelativeGap()) >= 0.0
+        end
+        if MOI.canget(instance, MOI.SolveTime())
+            @test MOI.get(instance, MOI.SolveTime()) >= 0.0
+        end
+        if MOI.canget(instance, MOI.SimplexIterations())
+            @test MOI.get(instance, MOI.SimplexIterations()) >= 0
+        end
+        if MOI.canget(instance, MOI.BarrierIterations())
+            @test MOI.get(instance, MOI.BarrierIterations()) >= 0
+        end
+        if MOI.canget(instance, MOI.NodeCount())
+            @test MOI.get(instance, MOI.NodeCount()) >= 0
+        end
     end
 end
 
@@ -135,46 +137,50 @@ function int2test(solver::Function, config::TestConfig)
         MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
         @test MOI.get(instance, MOI.ObjectiveSense()) == MOI.MaxSense
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.ResultCount())
-        @test MOI.get(instance, MOI.ResultCount()) >= 1
+            @test MOI.canget(instance, MOI.ResultCount())
+            @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.VariablePrimal(), v)
-        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0,1,2] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), v)
+            @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0,1,2] atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.DualStatus()) == false
+            @test MOI.canget(instance, MOI.DualStatus()) == false
+        end
 
         @test MOI.candelete(instance, c1)
         MOI.delete!(instance, c1)
         @test MOI.candelete(instance, c2)
         MOI.delete!(instance, c2)
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.ResultCount())
-        @test MOI.get(instance, MOI.ResultCount()) >= 1
+            @test MOI.canget(instance, MOI.ResultCount())
+            @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 5 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 5 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.VariablePrimal(), v)
-        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1,1,2] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), v)
+            @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1,1,2] atol=atol rtol=rtol
+        end
     end
     @testset "SOSII" begin
         #@test MOI.supportsproblem(solver,
@@ -234,48 +240,52 @@ function int2test(solver::Function, config::TestConfig)
         MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
         @test MOI.get(instance, MOI.ObjectiveSense()) == MOI.MaxSense
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.ResultCount())
-        @test MOI.get(instance, MOI.ResultCount()) >= 1
+            @test MOI.canget(instance, MOI.ResultCount())
+            @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 15.0 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 15.0 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.VariablePrimal(), v)
-        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 3.0, 12.0] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), v)
+            @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 3.0, 12.0] atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.DualStatus()) == false
+            @test MOI.canget(instance, MOI.DualStatus()) == false
+        end
 
         for cref in bin_constraints
             @test MOI.candelete(instance, cref)
             MOI.delete!(instance, cref)
         end
 
-        MOI.optimize!(instance)
+        if config.solve
+            MOI.optimize!(instance)
 
-        @test MOI.canget(instance, MOI.TerminationStatus())
-        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(instance, MOI.TerminationStatus())
+            @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(instance, MOI.ResultCount())
-        @test MOI.get(instance, MOI.ResultCount()) >= 1
+            @test MOI.canget(instance, MOI.ResultCount())
+            @test MOI.get(instance, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(instance, MOI.PrimalStatus())
-        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(instance, MOI.PrimalStatus())
+            @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 30.0 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ObjectiveValue())
+            @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 30.0 atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.VariablePrimal(), v)
-        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 2.0, 2.0, 0.0, 2.0, 0.0, 0.0, 6.0, 24.0] atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.VariablePrimal(), v)
+            @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 2.0, 2.0, 0.0, 2.0, 0.0, 0.0, 6.0, 24.0] atol=atol rtol=rtol
 
-        @test MOI.canget(instance, MOI.DualStatus()) == false
+            @test MOI.canget(instance, MOI.DualStatus()) == false
+        end
     end
 end
 
@@ -315,28 +325,30 @@ function int3test(solver::Function, config::TestConfig)
     MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(vcat(z, b[1:3]), vcat(1.0, fill(-0.5 / 40, 3)), 0.0))
     MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
-    # test for CPLEX.jl #76
-    MOI.optimize!(instance)
+        # test for CPLEX.jl #76
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+    end
 end
 
 
@@ -371,19 +383,21 @@ function knapsacktest(solver::Function, config::TestConfig)
         MOI.set!(instance, MOI.VariablePrimalStart(), v, [0.0, 0.0, 0.0, 0.0, 0.0])
     end
 
-    MOI.optimize!(instance)
+    if config.solve
+        MOI.optimize!(instance)
 
-    @test MOI.canget(instance, MOI.TerminationStatus())
-    @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
 
-    @test MOI.canget(instance, MOI.PrimalStatus())
-    @test MOI.get(instance, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
 
-    @test MOI.canget(instance, MOI.ObjectiveValue())
-    @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 16 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ 16 atol=atol rtol=rtol
 
-    @test MOI.canget(instance, MOI.VariablePrimal(), v)
-    @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 0, 0, 1, 1] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.VariablePrimal(), v)
+        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ [1, 0, 0, 1, 1] atol=atol rtol=rtol
+    end
 end
 
 const intlineartests = Dict("knapsack" => knapsacktest,


### PR DESCRIPTION
Setting `config.solve = false` allows the solver to skip `optimize!` and the result check in order to only check getter/setter for the instance.
It also allows `AbstractInstance` that are not `AbstractSolverInstance` to pass the tests.