### PR TITLE
Add rotatedsoc3

### DIFF
--- a/src/contconic.jl
+++ b/src/contconic.jl
@@ -714,6 +714,106 @@ function rotatedsoc2test(solver::Function, config::TestConfig)
     end
 end
 
+function rotatedsoc3test(solver::Function, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # Problem SOCRotated3
+    # max v
+    # s.t.
+    #      x[1:5] ≥ 0
+    #      0 ≤ u ≤ 5
+    #      v
+    #      t1 == 1
+    #      t2 == 1
+    # [t1/√2, t2/√2, x] in SOC7
+    # [x1/√2, u/√2,  v] in SOC3
+
+    instance = solver()
+
+    x = MOI.addvariables!(instance, 5)
+    u = MOI.addvariable!(instance)
+    v = MOI.addvariable!(instance)
+    t = MOI.addvariables!(instance, 2)
+
+    ct1 = MOI.addconstraint!(instance, MOI.SingleVariable(t[1]), MOI.EqualTo(1.0))
+    ct2 = MOI.addconstraint!(instance, MOI.SingleVariable(t[2]), MOI.EqualTo(1.0))
+    cx  = MOI.addconstraint!(instance, MOI.VectorOfVariables(x), MOI.Nonnegatives(5))
+    cu1 = MOI.addconstraint!(instance, MOI.SingleVariable(u), MOI.GreaterThan(0.0))
+    cu2 = MOI.addconstraint!(instance, MOI.SingleVariable(u), MOI.LessThan(5.0))
+
+    c1 = MOI.addconstraint!(instance, MOI.VectorAffineFunction(collect(1:7), [t; x], [1/√2; 1/√2; ones(5)], zeros(7)), MOI.RotatedSecondOrderCone(7))
+    c2 = MOI.addconstraint!(instance, MOI.VectorAffineFunction([1, 2, 3], [x[1], u, v], [1/√2; 1/√2; 1.0], zeros(3)), MOI.RotatedSecondOrderCone(3))
+
+    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 2
+    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
+    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
+    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
+    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
+    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.RotatedSecondOrderCone}()) == 2
+
+    MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([v],[1.0],0.0))
+    MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if config.solve
+        MOI.optimize!(instance)
+
+        @test MOI.canget(instance, MOI.TerminationStatus())
+        @test MOI.get(instance, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(instance, MOI.PrimalStatus())
+        @test MOI.get(instance, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(instance, MOI.DualStatus())
+            @test MOI.get(instance, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(instance, MOI.ObjectiveValue())
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ √5 atol=atol rtol=rtol
+
+        @test MOI.canget(instance, MOI.VariablePrimal(), MOI.VariableIndex)
+        @show MOI.get(instance, MOI.VariablePrimal(), x)
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ [1, 0, 0, 0, 0] atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), u) ≈ 5 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ √5 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), t) ≈ ones(2) atol=atol rtol=rtol
+
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(cx))
+        @test MOI.get(instance, MOI.ConstraintPrimal(), cx) ≈ [1, 0, 0, 0, 0] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(cu1))
+        @test MOI.get(instance, MOI.ConstraintPrimal(), cu1) ≈ 5 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(cu2))
+        @test MOI.get(instance, MOI.ConstraintPrimal(), cu2) ≈ 5 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(ct1))
+        @test MOI.get(instance, MOI.ConstraintPrimal(), ct1) ≈ 1.0 atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(ct1))
+        @test MOI.get(instance, MOI.ConstraintPrimal(), ct1) ≈ 1.0 atol=atol rtol=rtol
+
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(c1))
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c1) ≈ [1/√2, 1/√2, 1.0, 0.0, 0.0, 0.0, 0.0] atol=atol rtol=rtol
+        @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(c2))
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c2) ≈ [1/√2, 5/√2, √5] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(instance, MOI.ConstraintDual(), typeof(cx))
+            @show MOI.get(instance, MOI.ConstraintDual(), cx)
+            @test MOI.canget(instance, MOI.ConstraintDual(), typeof(cu1))
+            @test MOI.get(instance, MOI.ConstraintDual(), cu1) ≈ 0.0 atol=atol rtol=rtol
+            @test MOI.canget(instance, MOI.ConstraintDual(), typeof(cu2))
+            @show MOI.get(instance, MOI.ConstraintDual(), cu2)
+            @test MOI.canget(instance, MOI.ConstraintDual(), typeof(ct1))
+            @show MOI.get(instance, MOI.ConstraintDual(), ct1)
+            @test MOI.canget(instance, MOI.ConstraintDual(), typeof(ct1))
+            @show MOI.get(instance, MOI.ConstraintDual(), ct1)
+
+            @test MOI.canget(instance, MOI.ConstraintDual(), typeof(c1))
+            @show MOI.get(instance, MOI.ConstraintDual(), c1)
+            @test MOI.canget(instance, MOI.ConstraintDual(), typeof(c2))
+            @show MOI.get(instance, MOI.ConstraintDual(), c2)
+        end
+    end
+end
+
+
 const rsoctests = Dict("rotatedsoc1v" => rotatedsoc1vtest,
                        "rotatedsoc1f" => rotatedsoc1ftest,
                        "rotatedsoc2"  => rotatedsoc2test)

--- a/src/contconic.jl
+++ b/src/contconic.jl
@@ -714,34 +714,34 @@ function rotatedsoc2test(solver::Function, config::TestConfig)
     end
 end
 
-function rotatedsoc3test(solver::Function, config::TestConfig)
+function rotatedsoc3test(solver::Function, config::TestConfig; n=2, ub=3.0)
     atol = config.atol
     rtol = config.rtol
     # Problem SOCRotated3
     # max v
     # s.t.
-    #      x[1:5] ≥ 0
-    #      0 ≤ u ≤ 5
+    #      x[1:2] ≥ 0
+    #      0 ≤ u ≤ 3.0
     #      v
     #      t1 == 1
     #      t2 == 1
-    # [t1/√2, t2/√2, x] in SOC7
+    # [t1/√2, t2/√2, x] in SOC4
     # [x1/√2, u/√2,  v] in SOC3
 
     instance = solver()
 
-    x = MOI.addvariables!(instance, 5)
+    x = MOI.addvariables!(instance, n)
     u = MOI.addvariable!(instance)
     v = MOI.addvariable!(instance)
     t = MOI.addvariables!(instance, 2)
 
     ct1 = MOI.addconstraint!(instance, MOI.SingleVariable(t[1]), MOI.EqualTo(1.0))
     ct2 = MOI.addconstraint!(instance, MOI.SingleVariable(t[2]), MOI.EqualTo(1.0))
-    cx  = MOI.addconstraint!(instance, MOI.VectorOfVariables(x), MOI.Nonnegatives(5))
+    cx  = MOI.addconstraint!(instance, MOI.VectorOfVariables(x), MOI.Nonnegatives(n))
     cu1 = MOI.addconstraint!(instance, MOI.SingleVariable(u), MOI.GreaterThan(0.0))
-    cu2 = MOI.addconstraint!(instance, MOI.SingleVariable(u), MOI.LessThan(5.0))
+    cu2 = MOI.addconstraint!(instance, MOI.SingleVariable(u), MOI.LessThan(ub))
 
-    c1 = MOI.addconstraint!(instance, MOI.VectorAffineFunction(collect(1:7), [t; x], [1/√2; 1/√2; ones(5)], zeros(7)), MOI.RotatedSecondOrderCone(7))
+    c1 = MOI.addconstraint!(instance, MOI.VectorAffineFunction(collect(1:(2+n)), [t; x], [1/√2; 1/√2; ones(n)], zeros(2+n)), MOI.RotatedSecondOrderCone(2+n))
     c2 = MOI.addconstraint!(instance, MOI.VectorAffineFunction([1, 2, 3], [x[1], u, v], [1/√2; 1/√2; 1.0], zeros(3)), MOI.RotatedSecondOrderCone(3))
 
     @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 2
@@ -768,47 +768,46 @@ function rotatedsoc3test(solver::Function, config::TestConfig)
         end
 
         @test MOI.canget(instance, MOI.ObjectiveValue())
-        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ √5 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ObjectiveValue()) ≈ √ub atol=atol rtol=rtol
 
         @test MOI.canget(instance, MOI.VariablePrimal(), MOI.VariableIndex)
-        @show MOI.get(instance, MOI.VariablePrimal(), x)
-        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ [1, 0, 0, 0, 0] atol=atol rtol=rtol
-        @test MOI.get(instance, MOI.VariablePrimal(), u) ≈ 5 atol=atol rtol=rtol
-        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ √5 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), x) ≈ [1.0; zeros(n-1)] atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), u) ≈ ub atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.VariablePrimal(), v) ≈ √ub atol=atol rtol=rtol
         @test MOI.get(instance, MOI.VariablePrimal(), t) ≈ ones(2) atol=atol rtol=rtol
 
         @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(cx))
-        @test MOI.get(instance, MOI.ConstraintPrimal(), cx) ≈ [1, 0, 0, 0, 0] atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ConstraintPrimal(), cx) ≈ [1.0; zeros(n-1)] atol=atol rtol=rtol
         @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(cu1))
-        @test MOI.get(instance, MOI.ConstraintPrimal(), cu1) ≈ 5 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ConstraintPrimal(), cu1) ≈ ub atol=atol rtol=rtol
         @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(cu2))
-        @test MOI.get(instance, MOI.ConstraintPrimal(), cu2) ≈ 5 atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ConstraintPrimal(), cu2) ≈ ub atol=atol rtol=rtol
         @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(ct1))
         @test MOI.get(instance, MOI.ConstraintPrimal(), ct1) ≈ 1.0 atol=atol rtol=rtol
         @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(ct1))
         @test MOI.get(instance, MOI.ConstraintPrimal(), ct1) ≈ 1.0 atol=atol rtol=rtol
 
         @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(c1))
-        @test MOI.get(instance, MOI.ConstraintPrimal(), c1) ≈ [1/√2, 1/√2, 1.0, 0.0, 0.0, 0.0, 0.0] atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c1) ≈ [1/√2; 1/√2; 1.0; zeros(n-1)] atol=atol rtol=rtol
         @test MOI.canget(instance, MOI.ConstraintPrimal(), typeof(c2))
-        @test MOI.get(instance, MOI.ConstraintPrimal(), c2) ≈ [1/√2, 5/√2, √5] atol=atol rtol=rtol
+        @test MOI.get(instance, MOI.ConstraintPrimal(), c2) ≈ [1/√2, ub/√2, √ub] atol=atol rtol=rtol
 
         if config.duals
             @test MOI.canget(instance, MOI.ConstraintDual(), typeof(cx))
-            @show MOI.get(instance, MOI.ConstraintDual(), cx)
+            @test MOI.get(instance, MOI.ConstraintDual(), cx) ≈ zeros(n) atol=atol rtol=rtol
             @test MOI.canget(instance, MOI.ConstraintDual(), typeof(cu1))
             @test MOI.get(instance, MOI.ConstraintDual(), cu1) ≈ 0.0 atol=atol rtol=rtol
             @test MOI.canget(instance, MOI.ConstraintDual(), typeof(cu2))
-            @show MOI.get(instance, MOI.ConstraintDual(), cu2)
+            @test MOI.get(instance, MOI.ConstraintDual(), cu2) ≈ -1/(2*√ub) atol=atol rtol=rtol
             @test MOI.canget(instance, MOI.ConstraintDual(), typeof(ct1))
-            @show MOI.get(instance, MOI.ConstraintDual(), ct1)
+            @test MOI.get(instance, MOI.ConstraintDual(), ct1) ≈ -√ub/4 atol=atol rtol=rtol
             @test MOI.canget(instance, MOI.ConstraintDual(), typeof(ct1))
-            @show MOI.get(instance, MOI.ConstraintDual(), ct1)
+            @test MOI.get(instance, MOI.ConstraintDual(), ct1) ≈ -√ub/4 atol=atol rtol=rtol
 
             @test MOI.canget(instance, MOI.ConstraintDual(), typeof(c1))
-            @show MOI.get(instance, MOI.ConstraintDual(), c1)
+            @test MOI.get(instance, MOI.ConstraintDual(), c1) ≈ [√ub/(2*√2); √ub/(2*√2); -√ub/2; zeros(n-1)] atol=atol rtol=rtol
             @test MOI.canget(instance, MOI.ConstraintDual(), typeof(c2))
-            @show MOI.get(instance, MOI.ConstraintDual(), c2)
+            @test MOI.get(instance, MOI.ConstraintDual(), c2) ≈ [√ub/√2, 1/√(2*ub), -1.0] atol=atol rtol=rtol
         end
     end
 end
@@ -816,7 +815,8 @@ end
 
 const rsoctests = Dict("rotatedsoc1v" => rotatedsoc1vtest,
                        "rotatedsoc1f" => rotatedsoc1ftest,
-                       "rotatedsoc2"  => rotatedsoc2test)
+                       "rotatedsoc2"  => rotatedsoc2test,
+                       "rotatedsoc3"  => rotatedsoc3test)
 
 @moitestset rsoc
 


### PR DESCRIPTION
Add the test rotatedsoc3 from JuMP as JuMP's tests as it will [no longer be possible to tests solvers using JuMP's tests](https://github.com/JuliaOpt/JuMP.jl/pull/1158).
Closes #42