### PR TITLE
Remove solver as functions

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -20,8 +20,8 @@ end
 """
     @moitestset setname subsets
 
-Defines a function `setnametest(solver, config, exclude)` that runs the tests defined in the dictionary `setnametests`
-with the solver `solver` and config `config` except the tests whose dictionary key is in `exclude`.
+Defines a function `setnametest(instance, config, exclude)` that runs the tests defined in the dictionary `setnametests`
+with the instance `instance` and config `config` except the tests whose dictionary key is in `exclude`.
 If `subsets` is `true` then each test runs in fact multiple tests hence the `exclude` argument is passed
 as it can also contains test to be excluded from these subsets of tests.
 """
@@ -29,12 +29,12 @@ macro moitestset(setname, subsets=false)
     testname = Symbol(string(setname) * "test")
     testdict = Symbol(string(testname) * "s")
     if subsets
-        runtest = :( f(solver, config, exclude) )
+        runtest = :( f(instance, config, exclude) )
     else
-        runtest = :( f(solver, config) )
+        runtest = :( f(instance, config) )
     end
     :(
-        function $testname(solver::Function, config::TestConfig, exclude::Vector{String} = String[])
+        function $testname(instance::MOI.AbstractInstance, config::TestConfig, exclude::Vector{String} = String[])
             for (name,f) in $testdict
                 if name in exclude
                     continue

--- a/src/contconic.jl
+++ b/src/contconic.jl
@@ -3,10 +3,10 @@ const MOIU = MathOptInterfaceUtilities
 
 # Continuous conic problems
 
-function _lin1test(solver::Function, config::TestConfig, vecofvars::Bool)
+function _lin1test(instance::MOI.AbstractInstance, config::TestConfig, vecofvars::Bool)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver,
+    #@test MOI.supportsproblem(instance,
     #    MOI.ScalarAffineFunction{Float64},
     #    [
     #        (MOI.VectorOfVariables,MOI.Nonnegatives),
@@ -21,7 +21,8 @@ function _lin1test(solver::Function, config::TestConfig, vecofvars::Bool)
     #       x>=0 y>=0 z>=0
     # Opt obj = -11, soln x = 1, y = 0, z = 2
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     v = MOI.addvariables!(instance, 3)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 3
@@ -77,13 +78,13 @@ function _lin1test(solver::Function, config::TestConfig, vecofvars::Bool)
     end
 end
 
-lin1vtest(solver::Function, config::TestConfig) = _lin1test(solver, config, false)
-lin1ftest(solver::Function, config::TestConfig) = _lin1test(solver, config, false)
+lin1vtest(instance::MOI.AbstractInstance, config::TestConfig) = _lin1test(instance, config, false)
+lin1ftest(instance::MOI.AbstractInstance, config::TestConfig) = _lin1test(instance, config, false)
 
-function _lin2test(solver::Function, config::TestConfig, vecofvars::Bool)
+function _lin2test(instance::MOI.AbstractInstance, config::TestConfig, vecofvars::Bool)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64},
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64},
     #[
     #    (MOI.VectorAffineFunction{Float64},MOI.Zeros),
     #    (MOI.VectorOfVariables,MOI.Nonnegatives),
@@ -102,7 +103,8 @@ function _lin2test(solver::Function, config::TestConfig, vecofvars::Bool)
     # x = -4, y = -3, z = 16, s == 0
 
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x,y,z,s = MOI.addvariables!(instance, 4)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 4
@@ -179,13 +181,13 @@ function _lin2test(solver::Function, config::TestConfig, vecofvars::Bool)
     end
 end
 
-lin2vtest(solver::Function, config::TestConfig) = _lin2test(solver, config, true)
-lin2ftest(solver::Function, config::TestConfig) = _lin2test(solver, config, false)
+lin2vtest(instance::MOI.AbstractInstance, config::TestConfig) = _lin2test(instance, config, true)
+lin2ftest(instance::MOI.AbstractInstance, config::TestConfig) = _lin2test(instance, config, false)
 
-function lin3test(solver::Function, config::TestConfig)
+function lin3test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonpositives),(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives)])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonpositives),(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives)])
     # Problem LIN3 - Infeasible LP
     # min  0
     # s.t. x ≥ 1
@@ -195,7 +197,8 @@ function lin3test(solver::Function, config::TestConfig)
     # s.t. -1 + x ∈ R₊
     #       1 + x ∈ R₋
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariable!(instance)
 
@@ -225,10 +228,10 @@ function lin3test(solver::Function, config::TestConfig)
     end
 end
 
-function lin4test(solver::Function, config::TestConfig)
+function lin4test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.VectorOfVariables,MOI.Nonpositives)])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.VectorOfVariables,MOI.Nonpositives)])
     # Problem LIN4 - Infeasible LP
     # min  0
     # s.t. x ≥ 1
@@ -238,7 +241,8 @@ function lin4test(solver::Function, config::TestConfig)
     # s.t. -1 + x ∈ R₊
     #           x ∈ R₋
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariable!(instance)
 
@@ -278,16 +282,17 @@ const lintests = Dict("lin1v" => lin1vtest,
 
 @moitestset lin
 
-function _soc1test(solver::Function, config::TestConfig, vecofvars::Bool)
+function _soc1test(instance::MOI.AbstractInstance, config::TestConfig, vecofvars::Bool)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Zeros),(MOI.VectorOfVariables,MOI.SecondOrderCone)])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Zeros),(MOI.VectorOfVariables,MOI.SecondOrderCone)])
     # Problem SOC1
     # max 0x + 1y + 1z
     #  st  x            == 1
     #      x >= ||(y,z)||
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x,y,z = MOI.addvariables!(instance, 3)
 
@@ -346,13 +351,13 @@ function _soc1test(solver::Function, config::TestConfig, vecofvars::Bool)
     end
 end
 
-soc1vtest(solver::Function, config::TestConfig) = _soc1test(solver, config, true)
-soc1ftest(solver::Function, config::TestConfig) = _soc1test(solver, config, false)
+soc1vtest(instance::MOI.AbstractInstance, config::TestConfig) = _soc1test(instance, config, true)
+soc1ftest(instance::MOI.AbstractInstance, config::TestConfig) = _soc1test(instance, config, false)
 
-function _soc2test(solver::Function, config::TestConfig, nonneg::Bool)
+function _soc2test(instance::MOI.AbstractInstance, config::TestConfig, nonneg::Bool)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Zeros),(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone)])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Zeros),(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone)])
     # Problem SOC2
     # min  x
     # s.t. y ≥ 1/√2
@@ -363,7 +368,8 @@ function _soc2test(solver::Function, config::TestConfig, nonneg::Bool)
     #        1 - t ∈ {0}
     #      (t,x,y) ∈ SOC₃
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x,y,t = MOI.addvariables!(instance, 3)
 
@@ -420,13 +426,13 @@ function _soc2test(solver::Function, config::TestConfig, nonneg::Bool)
     end
 end
 
-soc2ntest(solver::Function, config::TestConfig) = _soc2test(solver, config, true)
-soc2ptest(solver::Function, config::TestConfig) = _soc2test(solver, config, false)
+soc2ntest(instance::MOI.AbstractInstance, config::TestConfig) = _soc2test(instance, config, true)
+soc2ptest(instance::MOI.AbstractInstance, config::TestConfig) = _soc2test(instance, config, false)
 
-function soc3test(solver::Function, config::TestConfig)
+function soc3test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.VectorAffineFunction{Float64},MOI.Nonpositives),(MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone)])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.VectorAffineFunction{Float64},MOI.Nonpositives),(MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone)])
     # Problem SOC3 - Infeasible
     # min 0
     # s.t. y ≥ 2
@@ -438,7 +444,8 @@ function soc3test(solver::Function, config::TestConfig)
     #      -1 + x ∈ R₋
     #       (x,y) ∈ SOC₂
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x,y = MOI.addvariables!(instance, 2)
 
@@ -468,10 +475,10 @@ function soc3test(solver::Function, config::TestConfig)
     end
 end
 
-function soc4test(solver::Function, config::TestConfig)
+function soc4test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.Zeros),(MOI.VectorOfVariables,MOI.SecondOrderCone)])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.Zeros),(MOI.VectorOfVariables,MOI.SecondOrderCone)])
     # Problem SOC4
     # min 0x[1] - 2x[2] - 1x[3]
     #  st  x[1]                                == 1 (c1a)
@@ -491,7 +498,8 @@ function soc4test(solver::Function, config::TestConfig)
           0.0  0.0  1.0  0.0 -1.0]
     c = [ 0.0,-2.0,-1.0, 0.0, 0.0]
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariables!(instance, 5)
 
@@ -547,10 +555,10 @@ const soctests = Dict("soc1v" => soc1vtest,
 
 @moitestset soc
 
-function _rotatedsoc1test(solver::Function, config::TestConfig, abvars::Bool)
+function _rotatedsoc1test(instance::MOI.AbstractInstance, config::TestConfig, abvars::Bool)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64},
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64},
     #    [(MOI.SingleVariable,MOI.EqualTo{Float64}),
     #     (MOI.VectorOfVariables,MOI.RotatedSecondOrderCone)])
     # Problem SOCRotated1v
@@ -565,7 +573,8 @@ function _rotatedsoc1test(solver::Function, config::TestConfig, abvars::Bool)
     #     [0.0] - [-y    ] SOCRotated
     #     [0.0] - [    -z] SOCRotated
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariables!(instance, 2)
     if abvars
@@ -637,13 +646,13 @@ function _rotatedsoc1test(solver::Function, config::TestConfig, abvars::Bool)
     end
 end
 
-rotatedsoc1vtest(solver::Function, config::TestConfig) = _rotatedsoc1test(solver, config, true)
-rotatedsoc1ftest(solver::Function, config::TestConfig) = _rotatedsoc1test(solver, config, false)
+rotatedsoc1vtest(instance::MOI.AbstractInstance, config::TestConfig) = _rotatedsoc1test(instance, config, true)
+rotatedsoc1ftest(instance::MOI.AbstractInstance, config::TestConfig) = _rotatedsoc1test(instance, config, false)
 
-function rotatedsoc2test(solver::Function, config::TestConfig)
+function rotatedsoc2test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64},
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64},
     #    [(MOI.SingleVariable,MOI.EqualTo{Float64}),
     #     (MOI.SingleVariable,MOI.LessThan{Float64}),
     #     (MOI.SingleVariable,MOI.GreaterThan{Float64}),
@@ -665,7 +674,8 @@ function rotatedsoc2test(solver::Function, config::TestConfig)
     b = [-2, -1, 1/2]
     c = [0.0,0.0,0.0]
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariables!(instance, 3)
 
@@ -714,7 +724,7 @@ function rotatedsoc2test(solver::Function, config::TestConfig)
     end
 end
 
-function rotatedsoc3test(solver::Function, config::TestConfig; n=2, ub=3.0)
+function rotatedsoc3test(instance::MOI.AbstractInstance, config::TestConfig; n=2, ub=3.0)
     atol = config.atol
     rtol = config.rtol
     # Problem SOCRotated3
@@ -728,7 +738,8 @@ function rotatedsoc3test(solver::Function, config::TestConfig; n=2, ub=3.0)
     # [t1/√2, t2/√2, x] in SOC4
     # [x1/√2, u/√2,  v] in SOC3
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariables!(instance, n)
     u = MOI.addvariable!(instance)
@@ -820,7 +831,7 @@ const rsoctests = Dict("rotatedsoc1v" => rotatedsoc1vtest,
 
 @moitestset rsoc
 
-function _geomean1test(solver::Function, config::TestConfig, vecofvars, n=3)
+function _geomean1test(instance::MOI.AbstractInstance, config::TestConfig, vecofvars, n=3)
     atol = config.atol
     rtol = config.rtol
     # Problem GeoMean1
@@ -837,7 +848,8 @@ function _geomean1test(solver::Function, config::TestConfig, vecofvars, n=3)
     # Therefore xyz ≤ 1
     # This can be attained using x = y = z = 1 so it is optimal.
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     t = MOI.addvariable!(instance)
     x = MOI.addvariables!(instance, n)
@@ -889,15 +901,15 @@ function _geomean1test(solver::Function, config::TestConfig, vecofvars, n=3)
     end
 end
 
-geomean1vtest(solver::Function, config::TestConfig) = _geomean1test(solver, config, true)
-geomean1ftest(solver::Function, config::TestConfig) = _geomean1test(solver, config, false)
+geomean1vtest(instance::MOI.AbstractInstance, config::TestConfig) = _geomean1test(instance, config, true)
+geomean1ftest(instance::MOI.AbstractInstance, config::TestConfig) = _geomean1test(instance, config, false)
 
 geomeantests = Dict("geomean1v" => geomean1vtest,
                     "geomean1f" => geomean1ftest)
 
 @moitestset geomean
 
-function _exp1test(solver::Function, config::TestConfig, vecofvars::Bool)
+function _exp1test(instance::MOI.AbstractInstance, config::TestConfig, vecofvars::Bool)
     atol = config.atol
     rtol = config.rtol
     # Problem EXP1 - ExpPrimal
@@ -906,7 +918,8 @@ function _exp1test(solver::Function, config::TestConfig, vecofvars::Bool)
     #      x == 1
     #      y == 2
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     v = MOI.addvariables!(instance, 3)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 3
@@ -966,16 +979,17 @@ function _exp1test(solver::Function, config::TestConfig, vecofvars::Bool)
     end
 end
 
-exp1vtest(solver::Function, config::TestConfig) = _exp1test(solver, config, true)
-exp1ftest(solver::Function, config::TestConfig) = _exp1test(solver, config, false)
+exp1vtest(instance::MOI.AbstractInstance, config::TestConfig) = _exp1test(instance, config, true)
+exp1ftest(instance::MOI.AbstractInstance, config::TestConfig) = _exp1test(instance, config, false)
 
-function exp2test(solver::Function, config::TestConfig)
+function exp2test(instance::MOI.AbstractInstance, config::TestConfig)
     # Problem EXP2
     # A problem where ECOS was failing
     atol = config.atol
     rtol = config.rtol
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     v = MOI.addvariables!(instance, 9)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 9
@@ -1046,13 +1060,14 @@ function exp2test(solver::Function, config::TestConfig)
     end
 end
 
-function exp3test(solver::Function, config::TestConfig)
+function exp3test(instance::MOI.AbstractInstance, config::TestConfig)
     # Problem EXP3
     # A problem where ECOS was failing
     atol = config.atol
     rtol = config.rtol
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
@@ -1111,16 +1126,17 @@ exptests = Dict("exp1v" => exp1vtest,
 
 @moitestset exp
 
-function _sdp0test(solver::Function, vecofvars::Bool, sdpcone, config::TestConfig)
+function _sdp0test(instance::MOI.AbstractInstance, vecofvars::Bool, sdpcone, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}), (MOI.VectorOfVariables, sdpcone)])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}), (MOI.VectorOfVariables, sdpcone)])
     # min X[1,1] + X[2,2]    max y
     #     X[2,1] = 1         [0   y/2     [ 1  0
     #                         y/2 0    <=   0  1]
     #     X >= 0              y free
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     X = MOI.addvariables!(instance, 3)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 3
@@ -1172,10 +1188,10 @@ function _sdp0test(solver::Function, vecofvars::Bool, sdpcone, config::TestConfi
 end
 
 
-function _sdp1test(solver::Function, vecofvars::Bool, sdpcone, config::TestConfig)
+function _sdp1test(instance::MOI.AbstractInstance, vecofvars::Bool, sdpcone, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}), (MOI.VectorOfVariables, sdpcone), (MOI.VectorOfVariables, MOI.SecondOrderCone)])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}), (MOI.VectorOfVariables, sdpcone), (MOI.VectorOfVariables, MOI.SecondOrderCone)])
     # Problem SDP1 - sdo1 from MOSEK docs
     # From Mosek.jl/test/mathprogtestextra.jl, under license:
     #   Copyright (c) 2013 Ulf Worsoe, Mosek ApS
@@ -1203,7 +1219,8 @@ function _sdp1test(solver::Function, vecofvars::Bool, sdpcone, config::TestConfi
     #      (x1,x2,x3) in C^3_q
     #      X in C_sdp
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     X = MOI.addvariables!(instance, 6)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 6
@@ -1297,17 +1314,18 @@ function _sdp1test(solver::Function, vecofvars::Bool, sdpcone, config::TestConfi
     end
 end
 
-sdp0tvtest(solver::Function, config::TestConfig) = _sdp0test(solver, true, MOI.PositiveSemidefiniteConeTriangle, config)
-sdp0tftest(solver::Function, config::TestConfig) = _sdp0test(solver, false, MOI.PositiveSemidefiniteConeTriangle, config)
-sdp1tvtest(solver::Function, config::TestConfig) = _sdp1test(solver, true, MOI.PositiveSemidefiniteConeTriangle, config)
-sdp1tftest(solver::Function, config::TestConfig) = _sdp1test(solver, false, MOI.PositiveSemidefiniteConeTriangle, config)
+sdp0tvtest(instance::MOI.AbstractInstance, config::TestConfig) = _sdp0test(instance, true, MOI.PositiveSemidefiniteConeTriangle, config)
+sdp0tftest(instance::MOI.AbstractInstance, config::TestConfig) = _sdp0test(instance, false, MOI.PositiveSemidefiniteConeTriangle, config)
+sdp1tvtest(instance::MOI.AbstractInstance, config::TestConfig) = _sdp1test(instance, true, MOI.PositiveSemidefiniteConeTriangle, config)
+sdp1tftest(instance::MOI.AbstractInstance, config::TestConfig) = _sdp1test(instance, false, MOI.PositiveSemidefiniteConeTriangle, config)
 
-function sdp2test(solver::Function, config::TestConfig)
+function sdp2test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}), (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle)])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}), (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle)])
     # Caused getdual to fail on SCS and Mosek
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariables!(instance, 7)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 7
@@ -1377,7 +1395,7 @@ const sdptests = Dict("sdp0tv" => sdp0tvtest,
 
 @moitestset sdp
 
-function _det1test(solver::Function, config::TestConfig, vecofvars::Bool, detcone)
+function _det1test(instance::MOI.AbstractInstance, config::TestConfig, vecofvars::Bool, detcone)
     atol = config.atol
     rtol = config.rtol
     square = detcone == MOI.LogDetConeSquare || detcone == MOI.RootDetConeSquare
@@ -1395,7 +1413,8 @@ function _det1test(solver::Function, config::TestConfig, vecofvars::Bool, detcon
     #           |_________|
     #            -Q22 ≥ -1
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     t = MOI.addvariable!(instance)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 1
@@ -1443,16 +1462,16 @@ function _det1test(solver::Function, config::TestConfig, vecofvars::Bool, detcon
     end
 end
 
-logdet1tvtest(solver::Function, config::TestConfig) = _det1test(solver, config, true, MOI.LogDetConeTriangle)
-logdet1tftest(solver::Function, config::TestConfig) = _det1test(solver, config, false, MOI.LogDetConeTriangle)
+logdet1tvtest(instance::MOI.AbstractInstance, config::TestConfig) = _det1test(instance, config, true, MOI.LogDetConeTriangle)
+logdet1tftest(instance::MOI.AbstractInstance, config::TestConfig) = _det1test(instance, config, false, MOI.LogDetConeTriangle)
 
 const logdettests = Dict("logdet1tv" => logdet1tvtest,
                          "logdet1tf" => logdet1tftest)
 
 @moitestset logdet
 
-rootdet1tvtest(solver::Function, config::TestConfig) = _det1test(solver, config, true, MOI.RootDetConeTriangle)
-rootdet1tftest(solver::Function, config::TestConfig) = _det1test(solver, config, false, MOI.RootDetConeTriangle)
+rootdet1tvtest(instance::MOI.AbstractInstance, config::TestConfig) = _det1test(instance, config, true, MOI.RootDetConeTriangle)
+rootdet1tftest(instance::MOI.AbstractInstance, config::TestConfig) = _det1test(instance, config, false, MOI.RootDetConeTriangle)
 
 const rootdettests = Dict("rootdet1tv" => rootdet1tvtest,
                           "rootdet1tf" => rootdet1tftest)

--- a/src/contlinear.jl
+++ b/src/contlinear.jl
@@ -3,7 +3,7 @@ using MathOptInterfaceUtilities # Defines isapprox for ScalarAffineFunction
 # Continuous linear problems
 
 # Basic solver, query, resolve
-function linear1test(solver::Function, config::TestConfig)
+function linear1test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # simple 2 variable, 1 constraint problem
@@ -11,13 +11,14 @@ function linear1test(solver::Function, config::TestConfig)
     # st   x + y <= 1   (x + y - 1 ∈ Nonpositives)
     #       x, y >= 0   (x, y ∈ Nonnegatives)
 
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
 
-    #@test MOI.get(solver, MOI.SupportsAddConstraintAfterSolve())
-    #@test MOI.get(solver, MOI.SupportsAddVariableAfterSolve())
-    #@test MOI.get(solver, MOI.SupportsDeleteConstraint())
+    #@test MOI.get(instance, MOI.SupportsAddConstraintAfterSolve())
+    #@test MOI.get(instance, MOI.SupportsAddVariableAfterSolve())
+    #@test MOI.get(instance, MOI.SupportsDeleteConstraint())
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     v = MOI.addvariables!(instance, 2)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 2
@@ -385,16 +386,17 @@ function linear1test(solver::Function, config::TestConfig)
 end
 
 # addvariable! (one by one)
-function linear2test(solver::Function, config::TestConfig)
+function linear2test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # Min -x
     # s.t. x + y <= 1
     # x, y >= 0
 
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
@@ -452,14 +454,15 @@ function linear2test(solver::Function, config::TestConfig)
 end
 
 # Issue #40 from Gurobi.jl
-function linear3test(solver::Function, config::TestConfig)
+function linear3test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # min  x
     # s.t. x >= 0
     #      x >= 3
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariable!(instance)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 1
@@ -495,7 +498,8 @@ function linear3test(solver::Function, config::TestConfig)
     # s.t. x <= 0
     #      x <= 3
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariable!(instance)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 1
@@ -529,13 +533,14 @@ function linear3test(solver::Function, config::TestConfig)
 end
 
 # Modify GreaterThan and LessThan sets as bounds
-function linear4test(solver::Function, config::TestConfig)
+function linear4test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.SingleVariable,MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.LessThan{Float64})])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.SingleVariable,MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.LessThan{Float64})])
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
@@ -593,10 +598,10 @@ function linear4test(solver::Function, config::TestConfig)
 end
 
 # Change coeffs, del constr, del var
-function linear5test(solver::Function, config::TestConfig)
+function linear5test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.get(solver, MOI.SupportsDeleteVariable())
+    #@test MOI.get(instance, MOI.SupportsDeleteVariable())
     #####################################
     # Start from simple LP
     # Solve it
@@ -613,7 +618,8 @@ function linear5test(solver::Function, config::TestConfig)
     #
     #   solution: x = 1.3333333, y = 1.3333333, objv = 2.66666666
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
@@ -737,13 +743,14 @@ function linear5test(solver::Function, config::TestConfig)
 end
 
 # Modify GreaterThan and LessThan sets as linear constraints
-function linear6test(solver::Function, config::TestConfig)
+function linear6test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64})])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64})])
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
@@ -801,13 +808,14 @@ function linear6test(solver::Function, config::TestConfig)
 end
 
 # Modify constants in Nonnegatives and Nonpositives
-function linear7test(solver::Function, config::TestConfig)
+function linear7test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonpositives),(MOI.VectorAffineFunction{Float64},MOI.Nonpositives)])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonpositives),(MOI.VectorAffineFunction{Float64},MOI.Nonpositives)])
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
@@ -865,15 +873,17 @@ function linear7test(solver::Function, config::TestConfig)
 end
 
 # infeasible problem
-function linear8atest(solver::Function, config::TestConfig)
+function linear8atest(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # min x
     # s.t. 2x+y <= -1
     # x,y >= 0
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
+
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
     c = MOI.addconstraint!(instance, MOI.ScalarAffineFunction([x,y], [2.0,1.0], 0.0), MOI.LessThan(-1.0))
@@ -911,15 +921,17 @@ function linear8atest(solver::Function, config::TestConfig)
 end
 
 # unbounded problem
-function linear8btest(solver::Function, config::TestConfig)
+function linear8btest(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # min -x-y
     # s.t. -x+2y <= 0
     # x,y >= 0
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
+
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
     MOI.addconstraint!(instance, MOI.ScalarAffineFunction([x,y], [-1.0,2.0], 0.0), MOI.LessThan(0.0))
@@ -947,15 +959,17 @@ function linear8btest(solver::Function, config::TestConfig)
 end
 
 # unbounded problem with unique ray
-function linear8ctest(solver::Function, config::TestConfig)
+function linear8ctest(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # min -x-y
     # s.t. x-y == 0
     # x,y >= 0
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
+
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
     MOI.addconstraint!(instance, MOI.ScalarAffineFunction([x,y], [1.0,-1.0], 0.0), MOI.EqualTo(0.0))
@@ -987,7 +1001,7 @@ function linear8ctest(solver::Function, config::TestConfig)
 end
 
 # addconstraints
-function linear9test(solver::Function, config::TestConfig)
+function linear9test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     #   maximize 1000 x + 350 y
@@ -1000,7 +1014,7 @@ function linear9test(solver::Function, config::TestConfig)
     #
     #   solution: (59.0909, 36.3636)
     #   objv: 71818.1818
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64},
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64},
     #    [
     #        (MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),
     #        (MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),
@@ -1008,7 +1022,9 @@ function linear9test(solver::Function, config::TestConfig)
     #    ]
     #)
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
+
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
 
@@ -1050,21 +1066,23 @@ function linear9test(solver::Function, config::TestConfig)
 end
 
 # ranged constraints
-function linear10test(solver::Function, config::TestConfig)
+function linear10test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     #   maximize x + y
     #
     #       s.t.  5 <= x + y <= 10
     #                  x,  y >= 0
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64},
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64},
     #    [
     #        (MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}),
     #        (MOI.SingleVariable,MOI.GreaterThan{Float64})
     #    ]
     #)
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
+
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
 
@@ -1137,21 +1155,22 @@ function linear10test(solver::Function, config::TestConfig)
 end
 
 # changing constraint sense
-function linear11test(solver::Function, config::TestConfig)
+function linear11test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # simple 2 variable, 1 constraint problem
     # min x + y
     # st   x + y >= 1
     #      x + y >= 2
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64},
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64},
     #    [
     #        (MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),
     #        (MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64})
     #    ]
     #)
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     v = MOI.addvariables!(instance, 2)
 
@@ -1186,16 +1205,18 @@ function linear11test(solver::Function, config::TestConfig)
 end
 
 # infeasible problem with 2 linear constraints
-function linear12test(solver::Function, config::TestConfig)
+function linear12test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # min x
     # s.t. 2x-3y <= -7
     #      y <= 2
     # x,y >= 0
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
+
     x = MOI.addvariable!(instance)
     y = MOI.addvariable!(instance)
     c1 = MOI.addconstraint!(instance, MOI.ScalarAffineFunction([x,y], [2.0,-3.0], 0.0), MOI.LessThan(-7.0))

--- a/src/contquadratic.jl
+++ b/src/contquadratic.jl
@@ -2,7 +2,7 @@ using MathOptInterfaceUtilities # Defines isapprox for ScalarQuadraticFunction
 
 # Continuous quadratic problems
 
-function qp1test(solver::Function, config::TestConfig)
+function qp1test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     @testset "QP1 - Quadratic objective" begin
@@ -12,9 +12,10 @@ function qp1test(solver::Function, config::TestConfig)
         #     x +  y      >= 1 (c2)
         #     x,y \in R
 
-        #@test MOI.supportsproblem(solver, MOI.ScalarQuadraticFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64})])
+        #@test MOI.supportsproblem(instance, MOI.ScalarQuadraticFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64})])
 
-        instance = solver()
+        MOI.empty!(instance)
+        @test MOI.isempty(instance)
 
         v = MOI.addvariables!(instance, 3)
         @test MOI.get(instance, MOI.NumberOfVariables()) == 3
@@ -60,7 +61,7 @@ function qp1test(solver::Function, config::TestConfig)
     end
 end
 
-function qp2test(solver::Function, config::TestConfig)
+function qp2test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     @testset "QP2" begin
@@ -72,9 +73,10 @@ function qp2test(solver::Function, config::TestConfig)
         #     x +  y      >= 1 (c2)
         #     x,y \in R
 
-        #@test MOI.supportsproblem(solver, MOI.ScalarQuadraticFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64})])
+        #@test MOI.supportsproblem(instance, MOI.ScalarQuadraticFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64})])
 
-        instance = solver()
+        MOI.empty!(instance)
+        @test MOI.isempty(instance)
 
         v = MOI.addvariables!(instance, 3)
         @test MOI.get(instance, MOI.NumberOfVariables()) == 3
@@ -91,7 +93,7 @@ function qp2test(solver::Function, config::TestConfig)
         MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
         @test MOI.get(instance, MOI.ObjectiveSense()) == MOI.MinSense
 
-        if config.query           
+        if config.query
             @test MOI.canget(instance, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
             @test obj ≈ MOI.get(instance, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
 
@@ -147,7 +149,7 @@ function qp2test(solver::Function, config::TestConfig)
     end
 end
 
-function qp3test(solver::Function, config::TestConfig)
+function qp3test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     @testset "qp3test - Linear Quadratic objective" begin
@@ -156,14 +158,16 @@ function qp3test(solver::Function, config::TestConfig)
         #       s.t.  x, y >= 0
         #             x + y = 1
 
-        #@test MOI.supportsproblem(solver, MOI.ScalarQuadraticFunction{Float64},
+        #@test MOI.supportsproblem(instance, MOI.ScalarQuadraticFunction{Float64},
         #    [
         #        (MOI.SingleVariable,MOI.GreaterThan{Float64}),
         #        (MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64})
         #    ]
         #)
 
-        instance = solver()
+        MOI.empty!(instance)
+        @test MOI.isempty(instance)
+
         x = MOI.addvariable!(instance)
         y = MOI.addvariable!(instance)
 
@@ -226,11 +230,11 @@ function qp3test(solver::Function, config::TestConfig)
 end
 
 
-function qptests(solver::Function; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+function qptests(instance::MOI.AbstractInstance; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
     @testset "Quadratic Programs (quad. objective)" begin
-        qp1test(solver, atol=atol, rtol=rtol)
-        qp2test(solver, atol=atol, rtol=rtol)
-        qp3test(solver, atol=atol, rtol=rtol)
+        qp1test(instance, atol=atol, rtol=rtol)
+        qp2test(instance, atol=atol, rtol=rtol)
+        qp3test(instance, atol=atol, rtol=rtol)
     end
 end
 
@@ -238,7 +242,7 @@ end
     Quadratically constrained programs
 =#
 
-function qcp1test(solver::Function, config::TestConfig)
+function qcp1test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     @testset "qcp1" begin
@@ -248,9 +252,10 @@ function qcp1test(solver::Function, config::TestConfig)
         #       x + y >= 0 (c1[2])
         #     0.5x^2 + y <= 2 (c2)
 
-        #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})])
+        #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})])
 
-        instance = solver()
+        MOI.empty!(instance)
+        @test MOI.isempty(instance)
 
         x = MOI.addvariable!(instance)
         y = MOI.addvariable!(instance)
@@ -306,16 +311,17 @@ function qcp1test(solver::Function, config::TestConfig)
 end
 
 
-function qcp2test(solver::Function, config::TestConfig)
+function qcp2test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     @testset "qcp2" begin
         # Max x
         # s.t. x^2 <= 2 (c)
 
-        #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})])
+        #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})])
 
-        instance = solver()
+        MOI.empty!(instance)
+        @test MOI.isempty(instance)
 
         x = MOI.addvariable!(instance)
         @test MOI.get(instance, MOI.NumberOfVariables()) == 1
@@ -360,16 +366,17 @@ function qcp2test(solver::Function, config::TestConfig)
     end
 end
 
-function qcp3test(solver::Function, config::TestConfig)
+function qcp3test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     @testset "qcp3" begin
         # Min -x
         # s.t. x^2 <= 2
 
-        #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})])
+        #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})])
 
-        instance = solver()
+        MOI.empty!(instance)
+        @test MOI.isempty(instance)
 
         x = MOI.addvariable!(instance)
         @test MOI.get(instance, MOI.NumberOfVariables()) == 1
@@ -414,11 +421,11 @@ function qcp3test(solver::Function, config::TestConfig)
     end
 end
 
-function qcptests(solver::Function; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+function qcptests(instance::MOI.AbstractInstance; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
     @testset "Quadratic Constrainted Programs (quad. constraints only)" begin
-        qcp1test(solver, atol=atol, rtol=rtol)
-        qcp2test(solver, atol=atol, rtol=rtol)
-        qcp3test(solver, atol=atol, rtol=rtol)
+        qcp1test(instance, atol=atol, rtol=rtol)
+        qcp2test(instance, atol=atol, rtol=rtol)
+        qcp3test(instance, atol=atol, rtol=rtol)
     end
 end
 
@@ -426,7 +433,7 @@ end
     SOCP
 =#
 
-function socp1test(solver::Function, config::TestConfig)
+function socp1test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     @testset "socp1" begin
@@ -435,9 +442,10 @@ function socp1test(solver::Function, config::TestConfig)
         #      x^2 + y^2 <= t^2 (c2)
         #      t >= 0 (bound)
 
-        #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64}), (MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}), (MOI.SingleVariable,MOI.GreaterThan{Float64})])
+        #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64}), (MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}), (MOI.SingleVariable,MOI.GreaterThan{Float64})])
 
-        instance = solver()
+        MOI.empty!(instance)
+        @test MOI.isempty(instance)
 
         x = MOI.addvariable!(instance)
         y = MOI.addvariable!(instance)
@@ -488,9 +496,9 @@ function socp1test(solver::Function, config::TestConfig)
     end
 end
 
-function socptests(solver::Function; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+function socptests(instance::MOI.AbstractInstance; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
     @testset "Second Order Cone Programs" begin
-        socp1test(solver, atol=atol, rtol=rtol)
+        socp1test(instance, atol=atol, rtol=rtol)
     end
 end
 

--- a/src/intconic.jl
+++ b/src/intconic.jl
@@ -1,7 +1,7 @@
 # Integer conic problems
 
-function intsoc1test(solver::Function; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, 
+function intsoc1test(instance::MOI.AbstractInstance; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, 
     #    [(MOI.VectorAffineFunction{Float64},MOI.Zeros),
     #     (MOI.SingleVariable,MOI.ZeroOne),
     #     (MOI.VectorOfVariables,MOI.SecondOrderCone)])
@@ -13,7 +13,8 @@ function intsoc1test(solver::Function; atol=Base.rtoldefault(Float64), rtol=Base
         #      x >= ||(y,z)||
         #      (y,z) binary
 
-        instance = solver()
+        MOI.empty!(instance)
+        @test MOI.isempty(instance)
 
         x,y,z = MOI.addvariables!(instance, 3)
 
@@ -54,10 +55,10 @@ function intsoc1test(solver::Function; atol=Base.rtoldefault(Float64), rtol=Base
     end
 end
 
-function intsoctests(solver::Function; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
-    intsoc1test(solver, atol=atol, rtol=rtol)
+function intsoctests(instance::MOI.AbstractInstance; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+    intsoc1test(instance, atol=atol, rtol=rtol)
 end
 
-function intconictests(solver::Function; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
-    intsoctests(solver, atol=atol, rtol=rtol)
+function intconictests(instance::MOI.AbstractInstance; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+    intsoctests(instance, atol=atol, rtol=rtol)
 end

--- a/src/intlinear.jl
+++ b/src/intlinear.jl
@@ -1,7 +1,7 @@
 using MathOptInterfaceUtilities
 
 # MIP01 from CPLEX.jl
-function int1test(solver::Function, config::TestConfig)
+function int1test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # an example on mixed integer programming
@@ -15,9 +15,10 @@ function int1test(solver::Function, config::TestConfig)
     #         y is integer: 0 <= y <= 10
     #         z is binary
 
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64}), (MOI.SingleVariable, MOI.ZeroOne), (MOI.SingleVariable, MOI.Integer)])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64}), (MOI.SingleVariable, MOI.ZeroOne), (MOI.SingleVariable, MOI.Integer)])
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
     v = MOI.addvariables!(instance, 3)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 3
@@ -99,15 +100,16 @@ Base.isapprox(a::T, b::T; kwargs...) where T <: Union{MOI.SOS1, MOI.SOS2} = isap
 Base.:(==)(a::MOI.VectorOfVariables, b::MOI.VectorOfVariables) = (a.variables == b.variables)
 
 # sos from CPLEX.jl" begin
-function int2test(solver::Function, config::TestConfig)
+function int2test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [ (MOI.VectorOfVariables, MOI.SOS1),
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [ (MOI.VectorOfVariables, MOI.SOS1),
     #                                                                    (MOI.VectorOfVariables, MOI.SOS2) ])
     @testset "SOSI" begin
-        #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorOfVariables,MOI.SOS1), (MOI.SingleVariable,MOI.LessThan{Float64})])
+        #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorOfVariables,MOI.SOS1), (MOI.SingleVariable,MOI.LessThan{Float64})])
 
-        instance = solver()
+        MOI.empty!(instance)
+        @test MOI.isempty(instance)
 
         v = MOI.addvariables!(instance, 3)
         @test MOI.get(instance, MOI.NumberOfVariables()) == 3
@@ -183,7 +185,7 @@ function int2test(solver::Function, config::TestConfig)
         end
     end
     @testset "SOSII" begin
-        #@test MOI.supportsproblem(solver,
+        #@test MOI.supportsproblem(instance,
         #    MOI.ScalarAffineFunction{Float64},
         #    [
         #        (MOI.VectorOfVariables,MOI.SOS1),
@@ -193,7 +195,8 @@ function int2test(solver::Function, config::TestConfig)
         #        ]
         #)
 
-        instance = solver()
+        MOI.empty!(instance)
+        @test MOI.isempty(instance)
 
         v = MOI.addvariables!(instance, 10)
         @test MOI.get(instance, MOI.NumberOfVariables()) == 10
@@ -290,7 +293,7 @@ function int2test(solver::Function, config::TestConfig)
 end
 
 # CPLEX #76
-function int3test(solver::Function, config::TestConfig)
+function int3test(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # integer knapsack problem
@@ -299,9 +302,10 @@ function int3test(solver::Function, config::TestConfig)
     #       b1, b2, ... b10 ∈ {0, 1}
     #       z in {0, 1, 2, ..., 100}
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64},
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64},
     #    [
     #        (MOI.SingleVariable,MOI.ZeroOne),
     #        (MOI.SingleVariable,MOI.Integer),
@@ -354,7 +358,7 @@ end
 
 # Mixed-integer linear problems
 
-function knapsacktest(solver::Function, config::TestConfig)
+function knapsacktest(instance::MOI.AbstractInstance, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # integer knapsack problem
@@ -362,9 +366,10 @@ function knapsacktest(solver::Function, config::TestConfig)
     # st  2a + 8b + 4c + 2d + 5e <= 10
     #                  a,b,c,d,e ∈ binary
 
-    instance = solver()
+    MOI.empty!(instance)
+    @test MOI.isempty(instance)
 
-    #@test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.SingleVariable,MOI.ZeroOne),(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64})])
+    #@test MOI.supportsproblem(instance, MOI.ScalarAffineFunction{Float64}, [(MOI.SingleVariable,MOI.ZeroOne),(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64})])
 
     v = MOI.addvariables!(instance, 5)
     @test MOI.get(instance, MOI.NumberOfVariables()) == 5


### PR DESCRIPTION
This has the advantage of also testing that `MOI.empty!` works correctly.