### PR TITLE
Add test for objective function with bad type

### DIFF
--- a/src/contlinear.jl
+++ b/src/contlinear.jl
@@ -47,6 +47,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
         vrs = MOI.get(model, MOI.ListOfVariableIndices())
         @test vrs == v || vrs == reverse(v)
 
+        @test !MOI.canget(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
         @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
 


### PR DESCRIPTION
See https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/97
Currently, we cannot test that it returns InexactError since CachingOptimizer returns ErrorException, probably we shouldn't be so restrictive in the doc.